### PR TITLE
feat(examples): added example to verify and create letters

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ We've provided various examples for you to try out [here](https://github.com/lob
 
 There are simple scripts to demonstrate how to create all the core Lob objects (checks, letters, postcards. etc.) As well as more complex examples that utilize other libraries and external files:
 
+- [Verifying and Creating Letters from CSV](https://github.com/lob/lob-python/blob/master/examples/verify_and_create_letters_from_csv/letter.py)
 - [Verifying Addresses in a CSV](https://github.com/lob/lob-python/blob/master/examples/verify_addresses_from_csv/verify_addresses_from_csv.py)
 - [Creating Dynamic Postcards with HTML and Data](https://github.com/lob/lob-python/blob/master/examples/create_postcards_from_csv/create_postcards_from_csv.py)
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -10,6 +10,17 @@ cd examples/
 
 ## Examples
 
+### Create letters from CSV
+
+An example showing how to validate and clean addresses from a CSV spreadsheet full of shipping addresses using Lob's [Address Verification API](https://lob.com/verification/address) and then using the cleaned, valid addresses to dynamically create sample billing letters with variable data using Lob's [Letter API](https://lob.com/services/letters).
+
+In order to run the program enter:
+
+```
+cd verify_and_create_letters_from_csv/
+python letter.py input.csv
+```
+
 ### Create postcards from CSV
 
 An example showing how to dynamically create postcards from a CSV using HTML, a custom font, variable data, and Lob's [Postcard API](https://lob.com/services/postcards).

--- a/examples/verify_and_create_letters_from_csv/input.csv
+++ b/examples/verify_and_create_letters_from_csv/input.csv
@@ -1,0 +1,8 @@
+name, amount,address1,address2,city,state,postcode
+Kelly Jones,185.54,185 Berry St,,San Francisco,CA,94107
+Margaret Smith,387.45,6575 W Rialto,,fresno,CA,93723
+Jess Smith,19.87,537 Fillmore Street, Apt #2,San Francicso,ca,94117
+Michael Thruman,347.21,1625 Post St,,San Francisco,CA,94115
+Gerald Merritt,278.40,333 Post St,,San Francisco,CA,94108
+Linda Anderson,425.40,655 Fake Address,Fake Apartment,Not a City,CA,06475-1246
+John Travolta,175.84,111 NotAnAddress,,San Francisco,CA,94107

--- a/examples/verify_and_create_letters_from_csv/letter.py
+++ b/examples/verify_and_create_letters_from_csv/letter.py
@@ -1,0 +1,119 @@
+# Usage
+# python verify.py input.csv
+import sys,os
+sys.path.insert(0, os.path.abspath(__file__+'../../../..'))
+
+import lob
+import csv
+import datetime
+
+lob.api_key = 'test_0dc8d51e0acffcb1880e0f19c79b2f5b0cc'
+
+skipFirstLine  = True
+
+# Column indices in CSV
+name      = 0
+amount    = 1
+address1  = 2;
+address2  = 3;
+city      = 4;
+state     = 5;
+postcode  = 6;
+country   = 'US'
+
+try:
+  sys.argv[1]
+except IndexError:
+  print "Please provide an input CSV file as an argument."
+  sys.exit()
+
+# Open input files
+inputFile = open(sys.argv[1], 'rU')
+csvInput = csv.reader(inputFile)
+
+# Create output files
+errors = open('errors.csv', 'w')
+verified = open('verified.csv', 'w')
+success = open('success.csv', 'w')
+
+# Loop through input CSV rows
+for idx, row in enumerate(csvInput):
+  if skipFirstLine and idx == 0:
+    continue
+
+  # Sanity check
+  sys.stdout.write('.')
+  sys.stdout.flush()
+
+  # Verify addresses
+  try:
+    verifiedAddress = lob.Verification.create(
+      address_line1 = row[address1],
+      address_line2 = row[address2],
+      address_city = row[city],
+      address_state = row[state],
+      address_zip = row[postcode],
+      address_country = country
+    )
+  except Exception, e:
+    outputRow = ",".join(row) + "," + str(e)+ "\n"
+    errors.write(outputRow)
+  else:
+    outputRow  = row[name] + ","
+    outputRow += row[amount] + ","
+    outputRow += verifiedAddress.address.address_line1 + ","
+    outputRow += verifiedAddress.address.address_line2 + ","
+    outputRow += verifiedAddress.address.address_city + ","
+    outputRow += verifiedAddress.address.address_state + ","
+    outputRow += verifiedAddress.address.address_zip + "\n"
+    verified.write(outputRow)
+
+    # Create letter for verified addresses
+    try:
+      createdLetter = lob.Letter.create(
+          description = 'Bill for ' + row[name],
+          metadata = {
+              'campaign': 'billing_statements'
+          },
+          to_address = {
+              'name': row[name],
+              'address_line1': verifiedAddress.address.address_line1,
+              'address_city': verifiedAddress.address.address_city,
+              'address_zip': verifiedAddress.address.address_zip,
+              'address_state': verifiedAddress.address.address_state,
+          },
+          from_address = {
+              'name': 'Your Name/Company',
+              'address_line1': '123 Test Avenue',
+              'address_city': 'San Francisco',
+              'address_state': 'CA',
+              'address_zip': '94107',
+          },
+          file = open('letter_template.html', 'r').read(),
+          data = {
+              'date': datetime.datetime.now().strftime("%m/%d/%Y"),
+              'name': row[name],
+              'amountDue': row[amount]
+          },
+          color = True
+      )
+    except Exception, e:
+      print "Error: " + str(e) + " in " + str(row)
+    else:
+      outputRow = createdLetter.id + ","
+      outputRow += createdLetter.url + ","
+      outputRow += row[name] + ","
+      outputRow += row[amount] + ","
+      outputRow += (createdLetter.to_address.address_line1 if createdLetter.to_address.address_line1 != None else " ") + ","
+      outputRow += (createdLetter.to_address.address_line2 if createdLetter.to_address.address_line2 != None else " ") + ","
+      outputRow += (createdLetter.to_address.address_city  if createdLetter.to_address.address_city  != None else " ") + ","
+      outputRow += (createdLetter.to_address.address_state if createdLetter.to_address.address_state != None else " ") + ","
+      outputRow += (createdLetter.to_address.address_zip   if createdLetter.to_address.address_zip   != None else " ") + "\n"
+      success.write(outputRow)
+
+
+errors.close()
+verified.close()
+success.close()
+print "\n"
+

--- a/examples/verify_and_create_letters_from_csv/letter_template.html
+++ b/examples/verify_and_create_letters_from_csv/letter_template.html
@@ -1,0 +1,78 @@
+<!doctype html>
+<html>
+ <head>
+   <title></title>
+   <style>
+     @font-face {
+       font-family: 'Loved by the King';
+       font-style: normal;
+       font-weight: 400;
+       src: url('https://s3-us-west-2.amazonaws.com/lob-assets/LovedbytheKing.ttf') format('truetype');
+     }
+
+     *, *:before, *:after {
+
+       -webkit-box-sizing: border-box;
+       -moz-box-sizing: border-box;
+       box-sizing: border-box;
+     }
+     body {
+       width: 8.5in;
+       height: 11in;
+       margin: 0;
+       padding: 0;
+       font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+     }
+     .page {
+       page-break-after: always;
+     }
+     .page-content {
+       position: relative;
+       width: 7in;
+       height: 10.625in;
+       left: 0.75in;
+       top: 0.1875in;
+     }
+
+     #logo {
+       position: absolute;
+       right: 0;
+     }
+
+     .wrapper {
+       position: absolute;
+       top: 2.75in;
+     }
+
+     .signature {
+       font-family: 'Loved by the King';
+       font-size: 45px;
+     }
+   </style>
+ </head>
+ <body>
+   <div class='page'>
+     <div class='page-content'>
+       <img id="logo" src="https://s3-us-west-2.amazonaws.com/lob-assets/deluxe-logo.png" width="150px" />
+
+       <div class='wrapper'>
+           <p>{{date}}</p>
+
+           <p>Dear {{name}},</p>
+
+           <p>This is a friendly reminder that your account with us appears as past due. Our records indicate that you have
+           a total outstanding balance of <b>${{amountDue}}</b>.</p>
+
+           <p>We would much appreciate if you could let us know the status of this payment. Please do not hesitate to call
+           us if you have any questions about the balance due on your account. If you have already sent us your payment,
+           please disregard this reminder.</p>
+
+           <p>Thank you very much for your attention to this matter and your continued business.</p>
+
+           <p>Sincerely,</p>
+           <p class="signature">Deluxe</p>
+       </div>
+     </div>
+   </div>
+ </body>
+</html>


### PR DESCRIPTION
What: an example to verify and create letters

Why: allow customer to try out a test script that would take their csv file and generate letters for billing

Details:
 - navigate to ```examples/verify_and_create_letters_from_csv/``` folder 
 - run ```python letter.py input.csv```
 - fixes: https://github.com/lob/lob-api/issues/1791

@russelltaylor05 @pon @mgartner @robinjoseph08 @elnaz 
