### PR TITLE
feat(params): single object list parameters serialized as arrays

### DIFF
--- a/lob/resource.py
+++ b/lob/resource.py
@@ -99,6 +99,10 @@ class APIResource(LobObject):
 class ListableAPIResource(APIResource):
     @classmethod
     def list(cls, **params):
+        for key in params.keys():
+            if isinstance(params[key], list):
+                params[str(key) + '[]'] = params[key]
+                del params[key]
         requestor = api_requestor.APIRequestor()
         response = requestor.request('get', cls.endpoint, params)
         return lob_format(response)

--- a/tests/test_address.py
+++ b/tests/test_address.py
@@ -13,6 +13,12 @@ class TestAddressFunctions(unittest.TestCase):
         self.assertTrue(isinstance(addresses.data[0], lob.Address))
         self.assertEqual(addresses.object, 'list')
 
+    def test_list_addresses_total_count(self):
+        addresses = lob.Address.list(include=['total_count'])
+        self.assertTrue(isinstance(addresses.data[0], lob.Address))
+        self.assertEqual(addresses.object, 'list')
+        self.assertTrue(addresses['total_count'])
+
     def test_list_addresses_limit(self):
         addresses = lob.Address.list(count=2)
         self.assertTrue(isinstance(addresses.data[0], lob.Address))
@@ -62,4 +68,3 @@ class TestAddressFunctions(unittest.TestCase):
         )
 
         self.assertEqual(addr.address.address_line1, '220 WILLIAM T MORRISSEY BLVD')
-


### PR DESCRIPTION
What: list parameters are serialized as arrays to the API endpoint

Why: allows the wrapper to use array parameters

Detail:
- Allows you to pass array parameters into the wrapper
- `lob.Address.list(include=['total_count'])`

@pon @mgartner @elnaz @robinjoseph08 @neelk07 