### PR TITLE
fix(metadata): add metadata support to ListableAPIResource

### DIFF
--- a/lob/resource.py
+++ b/lob/resource.py
@@ -99,8 +99,12 @@ class APIResource(LobObject):
 class ListableAPIResource(APIResource):
     @classmethod
     def list(cls, **params):
-        for key in params.keys():
-            if isinstance(params[key], list):
+        for key, value in params.items():
+            if isinstance(params[key], dict):
+                for subKey in value:
+                    params[str(key) + '[' + subKey + ']'] = value[subKey]
+                del params[key]
+            elif isinstance(params[key], list):
                 params[str(key) + '[]'] = params[key]
                 del params[key]
         requestor = api_requestor.APIRequestor()

--- a/tests/test_postcard.py
+++ b/tests/test_postcard.py
@@ -18,6 +18,11 @@ class PostcardFunctions(unittest.TestCase):
         self.assertTrue(isinstance(postcards.data[0], lob.Postcard))
         self.assertEqual(len(postcards.data), 2)
 
+    def test_list_postcards_metadata(self):
+        postcards = lob.Postcard.list(metadata={ 'campagin': 'LOB2015' })
+        self.assertTrue(isinstance(postcards.data[0], lob.Postcard))
+        self.assertEqual(len(postcards.data), 1)
+
     def test_list_postcards_fail(self):
         self.assertRaises(lob.error.InvalidRequestError, lob.Postcard.list, count=1000)
 


### PR DESCRIPTION
What: 
- Add object support as arguments to ListableAPIResources
- Allows wrapper to use `metadata = { 'campaign' : 'NEWYORK2015' }` on `.list()` methods
- Fixes #86 


