### PR TITLE
fix(examples): rename check file to check_bottom

### DIFF
--- a/examples/check.py
+++ b/examples/check.py
@@ -82,7 +82,7 @@ example_check = lob.Check.create(
     bank_account = example_bank_account,
     amount = 1000,
     memo = 'Services Rendered',
-    file = """
+    check_bottom = """
       <html>
         <head>
           <style>


### PR DESCRIPTION
There weren't any changes necessary to the check tests or resource.