### PR TITLE
fix(readme): link to instructions for each example

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,9 @@ We've provided various examples for you to try out [here](https://github.com/lob
 
 There are simple scripts to demonstrate how to create all the core Lob objects (checks, letters, postcards. etc.) As well as more complex examples that utilize other libraries and external files:
 
-- [Verifying and Creating Letters from CSV](https://github.com/lob/lob-python/blob/master/examples/verify_and_create_letters_from_csv/letter.py)
-- [Verifying Addresses in a CSV](https://github.com/lob/lob-python/blob/master/examples/verify_addresses_from_csv/verify_addresses_from_csv.py)
-- [Creating Dynamic Postcards with HTML and Data](https://github.com/lob/lob-python/blob/master/examples/create_postcards_from_csv/create_postcards_from_csv.py)
+- [Verifying and Creating Letters from CSV](https://github.com/lob/lob-python/tree/master/examples#create-letters-from-csv)
+- [Verifying Addresses in a CSV](https://github.com/lob/lob-python/tree/master/examples#verify-addresses-from-csv)
+- [Creating Dynamic Postcards with HTML and Data](https://github.com/lob/lob-python/tree/master/examples#create-postcards-from-csv)
 
 ## API Documentation
 


### PR DESCRIPTION
Leore noticed that, from the project readme, if you click on the link for specific examples, we take you directly to the example source which may leave you wondering how to run that source. This changes the project readme links to point to the section of the example readme that examples how to run the example.

Fixes https://github.com/lob/lob-python/issues/96