### PR TITLE
fix(dependencies): stricter requirements for requests package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 nose
 flake8
-requests
+requests<2.11
 coverage<4
 coveralls


### PR DESCRIPTION
What: Uses an older version of the requests package
Why: Latest update to requests uses unicodes for their error messages which are not supported in Python 3.2.6