### PR TITLE
Update packaging / test metadata

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,11 @@ language: python
 python:
 - '2.6'
 - '2.7'
-- '3.2'
 - '3.3'
 - '3.4'
+- '3.5'
+- 'pypy'
+- 'pypy3'
 install:
   - pip install -r requirements.txt
 script:

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,6 @@ setup (
             "Programming Language :: Python :: 3.4",
             "Programming Language :: Python :: 3.5",
             "Programming Language :: Python :: Implementation :: CPython",
-            "Programming Language :: Python :: Implementation :: PyPy",
-        ],
+            "Programming Language :: Python :: Implementation :: PyPy"
+        ]
       )

--- a/setup.py
+++ b/setup.py
@@ -17,4 +17,16 @@ setup (
         install_requires = [
             'requests'
             ],
-        )
+        classifiers=[
+            "Development Status :: 5 - Production/Stable",
+            "License :: OSI Approved :: MIT License",
+            "Programming Language :: Python",
+            "Programming Language :: Python :: 2.7",
+            "Programming Language :: Python :: 3",
+            "Programming Language :: Python :: 3.3",
+            "Programming Language :: Python :: 3.4",
+            "Programming Language :: Python :: 3.5",
+            "Programming Language :: Python :: Implementation :: CPython",
+            "Programming Language :: Python :: Implementation :: PyPy",
+        ],
+      )

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,11 @@
+[tox]
+envlist = py27,py33,py34,py35,pypy,pypy3
+
+[testenv]
+usedevelop = True
+commands =
+  rm -f .coverage*
+  nosetests  --with-coverage --cover-package=lob
+deps =
+  -r{toxinidir}/requirements.txt
+whitelist_externals = rm


### PR DESCRIPTION
This pull request alters the set of tested and listed python versions in the following ways:
- Remove support for Python 3.2. Pip has now dropped support for it, which
  makes even running CI builds a challenge. It is also used by an [order-of-magnitude fewer people than use 3.3](http://www.randalolson.com/2016/09/03/python-2-7-still-reigns-supreme-in-pip-installs/) based on data from Randy Olsen.
- Add tox.ini to simplify running the build matrix locally.
- Add support for pypy and pypy3.
- Update classifiers in setup.py to include license (BSD) and the list of supported
  versions. This means that the lob client is unequivocally shown as python 3 compatible
  to tools like [`caniusepython3`](https://github.com/brettcannon/caniusepython3/blob/0d025e23c5ee25dd26111f26495858b5aa133236/caniusepython3/pypi.py#L72).

The reason for this change is that the `lob` dependency was listed as a Python 3 blocker in a large Python 2 application at Counsyl. Upon further investigation, I discovered that the Lob client is Python 3 compatible, but was not properly labeling itself as such.