### PR TITLE
fix(checks): Removes race condition in checks due to verified bank ac…

### DIFF
--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -5,9 +5,13 @@ class CheckFunctions(unittest.TestCase):
     def setUp(self):
         lob.api_key = 'test_fc26575412e92e22a926bc96c857f375f8b'
         self.addr = lob.Address.list(limit=1).data[0]
-        self.ba = lob.BankAccount.list(limit=1).data[0]
-        if self.ba.verified == False:
-            lob.BankAccount.verify(id=self.ba.id, amounts=[20,80])
+        self.ba = lob.BankAccount.create(
+            routing_number = '122100024',
+            account_number = '123456789',
+            account_type = 'company',
+            signatory = 'John Doe'
+        )
+        lob.BankAccount.verify(id=self.ba.id, amounts=[20, 80])
 
     def test_list_checks(self):
         checks = lob.Check.list()


### PR DESCRIPTION
…counts

JIRA: ENG-1102

What: 
- Remove race condition that the tests were getting the same unverified bank account and verifying it at the same time (one will fail)

Why: 
- The random failures are false-positive distractions that make our builds look broken sinking time into rerunning them with no guarantee of them passing the next time