### PR TITLE
refactor(verify): clean up verify address from csv example

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ We've provided various examples for you to try out [here](https://github.com/lob
 
 There are simple scripts to demonstrate how to create all the core Lob objects (checks, letters, postcards. etc.) As well as more complex examples that utilize other libraries and external files:
 
-- [Verifying and Creating Letters from CSV](https://github.com/lob/lob-python/tree/master/examples#create-letters-from-csv)
+- [Creating Letters from CSV](https://github.com/lob/lob-python/tree/master/examples#create-letters-from-csv)
 - [Verifying Addresses in a CSV](https://github.com/lob/lob-python/tree/master/examples#verify-addresses-from-csv)
 - [Creating Dynamic Postcards with HTML and Data](https://github.com/lob/lob-python/tree/master/examples#create-postcards-from-csv)
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -38,7 +38,7 @@ An example showing how to validate and cleanse a CSV spreadsheet full of shippin
 
 ```
 cd verify_addresses_from_csv/
-python verify_addresses_from_csv.py input.csv
+python verify.py input.csv
 ```
 
 ### Create a check

--- a/examples/verify_addresses_from_csv/verify.py
+++ b/examples/verify_addresses_from_csv/verify.py
@@ -1,70 +1,110 @@
-# Usage
-# python verify.py input.csv
+# usage:
+#     python verify.py input.csv
+#     logs output in csv directory
 
 import csv
+import datetime
 import lob
 import os
 import sys
 
 sys.path.insert(0, os.path.abspath(__file__+'../../../..'))
 
+# TODO: Provide your API key, keep this secure
 lob.api_key = 'test_fc26575412e92e22a926bc96c857f375f8b'
 
-skipFirstLine = True
-
-# Column indices in CSV
-address1 = 0
-address2 = 1
-city = 2
-state = 3
-postcode = 4
-country = 'US'
-
-try:
-    sys.argv[1]
-except IndexError:
+# Input check
+if len(sys.argv) < 2:
     print("Please provide an input CSV file as an argument.")
-    print("Usage: python verify.py <csv-input>")
+    print("usage: python verify.py <CSV_FILE>")
     sys.exit(1)
 
-# Open input files
-inputFile = open(sys.argv[1], 'rU')
-csvInput = csv.reader(inputFile)
+input_filename = sys.argv[1]
 
-# Create output files
-cwd = os.path.dirname(os.path.abspath(__file__))
-errors = open(cwd + '/errors.csv', 'w')
-verified = open(cwd + '/verified.csv', 'w')
+success_csv_fields = [
+    'address_line1',
+    'address_line2',
+    'address_city',
+    'address_state',
+    'address_zip'
+]
+errors_csv_fields = ['error']
 
-# Loop through input CSV rows
-for idx, row in enumerate(csvInput):
-    if skipFirstLine and idx == 0:
-        continue
+#create the output directory,
+output_dir = os.path.join('.',  'output')
+if not os.path.isdir(output_dir):
+    os.mkdir(output_dir)
 
-    # sanity check
-    sys.stdout.write('.')
-    sys.stdout.flush()
+timestamp = datetime.datetime.now().strftime('%Y-%m-%d_%H-%M-%S')
 
-    try:
-        verifiedAddress = lob.Verification.create(
-            address_line1=row[address1],
-            address_line2=row[address2],
-            address_city=row[city],
-            address_state=row[state],
-            address_zip=row[postcode],
-            address_country=country
-        )
-    except Exception, e:
-        outputRow = ",".join(row) + "," + str(e) + "\n"
-        errors.write(outputRow)
-else:
-    outputRow = verifiedAddress.address.address_line1 + ","
-    outputRow += verifiedAddress.address.address_line2 + ","
-    outputRow += verifiedAddress.address.address_city + ","
-    outputRow += verifiedAddress.address.address_state + ","
-    outputRow += verifiedAddress.address.address_zip + "\n"
-    verified.write(outputRow)
+try:
+    output_dir = os.path.join(output_dir, timestamp)
+    os.mkdir(output_dir)
+except Exception, e:
+    print('Error: ' + str(e))
+    print('Failed to create output directory. Aborting all sends.')
+    sys.exit(1)
 
-errors.close()
-verified.close()
-print "\n"
+# output csv names
+success_filename = os.path.join(output_dir, 'success.csv')
+errors_filename = os.path.join(output_dir, 'errors.csv')
+
+try:
+    with open(input_filename, 'r') as input, \
+         open(success_filename, 'w') as success, \
+         open(errors_filename, 'w') as errors:
+
+    # print mode to screen
+
+        input_csv = csv.DictReader(input)
+        errors_csv_fields += input_csv.fieldnames
+
+        success_csv = csv.DictWriter(success, fieldnames=success_csv_fields)
+        errors_csv = csv.DictWriter(errors, fieldnames=errors_csv_fields)
+
+        err_count = 0
+
+        # Loop through input CSV rows
+        for idx, row in enumerate(input_csv):
+            # Create letter from row
+            try:
+                verifiedAddress = lob.Verification.create(
+                    address_line1=row['address1'],
+                    address_line2=row['address2'],
+                    address_city=row['city'],
+                    address_state=row['state'],
+                    address_zip=row['postcode'],
+                    address_country='US'
+                )
+            except Exception, e:
+                error_row = {'error': e}
+                error_row.update(row)
+                errors_csv.writerow(error_row)
+                err_count += 1
+                sys.stdout.write('E')
+                sys.stdout.flush()
+            else:
+                success_csv.writerow({
+                    'address_line1': verifiedAddress.address.address_line1,
+                    'address_line2': verifiedAddress.address.address_line2,
+                    'address_city':  verifiedAddress.address.address_city,
+                    'address_state': verifiedAddress.address.address_state,
+                    'address_zip':   verifiedAddress.address.address_zip
+                })
+
+                # Print success
+                sys.stdout.write('.')
+                sys.stdout.flush()
+
+            # New lines for larger csv's
+            if idx % 10 is 9:
+                sys.stdout.write('\n')
+                sys.stdout.flush()
+
+except Exception, e:
+    print('Error: ' + str(e))
+    sys.exit(1)
+
+print('')
+print('Done with ' + (str(err_count) if err_count else 'no') + ' errors.')
+print('Results written to ' + str(output_dir) + '.')


### PR DESCRIPTION
What: Fixed up verify address example. Created in new PR because old one had strange git issues and I decided a clean install was the way to go. Original (with comments) is [here](https://github.com/lob/lob-python/pull/119)
Why: Part of an accross the board improvement on python.