### PR TITLE
chore(tests): remove pypy3 and add python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ python:
 - '3.3'
 - '3.4'
 - '3.5'
+- '3.6'
 - 'pypy'
-- 'pypy3'
 install:
   - pip install -r requirements.txt
 script:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 nose
 flake8
 requests
-coverage<4
+coverage
 coveralls

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py33,py34,py35,pypy,pypy3
+envlist = py27,py33,py34,py35,py36,pypy
 
 [testenv]
 usedevelop = True


### PR DESCRIPTION
**What**
- [X] Adds Python 3.6 as a version to test against
- [x] Removes `pypy3` as a version to test against
  - `pypy3` uses Python 3.2  which caused major headaches for Python package maintainers and as such they simply decided to drop support for such version. `coverage`, one of our dependencies now explicitly forbids the use of Python 3.2 so the builds have started failing. We stopped supporting Python 3.2 since #115 so there's no point in testing against it anymore.
- [x] Upgrade our `coverage` dependency
  - Now that we're no longer testing against Python 3.2, we can upgrade our coverage version once more.
  - We had previously limited our version of coverage in order to support Python 3.2 #89

**Why**
Since I was the last person to push a commit, I'm the one who started getting the annoying messages that the build is broken... σ(￣、￣〃)	