### PR TITLE
feat(verifications): add us and intl verification endpoints ENG-2767

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Here's a general overview of the Lob services available, click through to read m
 - [Letters API](https://lob.com/services/letters)
 - [Checks API](https://lob.com/services/checks)
 - [Area Mail API](https://lob.com/services/area)
-- [Address Verification API](https://lob.com/verification/address)
+- [Address Verification API](https://lob.com/services/verifications)
 
 ### Registration
 
@@ -84,8 +84,13 @@ There are simple scripts to demonstrate how to create all the core Lob objects (
     - [Retrieve an Address](https://lob.com/docs/python#addresses_retrieve)
     - [Delete an Address](https://lob.com/docs/python#addresses_delete)
     - [List all Addresses](https://lob.com/docs/python#addresses_list)
-  - [Address Verification API](https://lob.com/docs/python#verify)
-    - [Verify an Address](https://lob.com/docs/python#verify_create)
+- **US Verification API**
+  - [US Verification API](https://lob.com/docs/python#us_verifications)
+    - [The US Verification Object](https://lob.com/docs/python#us_verifications_object)
+    - [Verify a US Address](https://lob.com/docs/python#us_verifications_create)
+- **Int'l Verification API**
+  - [International Verifications](https://lob.com/docs/python#intl_verifications)
+    - [Verify an International Address](https://lob.com/docs/python#intl_verifications_create)
 - **Postcards API**
   - [Postcards](https://lob.com/docs/python#postcards)
     - [The Postcard Object](https://lob.com/docs/python#postcards_object)
@@ -132,6 +137,7 @@ There are simple scripts to demonstrate how to create all the core Lob objects (
   - [Events](https://lob.com/docs/python#events)
   - [HTML Examples](https://lob.com/docs/python#html-examples)
   - [Image Prepping](https://lob.com/docs/python#prepping)
+  - [US Verification Details](https://lob.com/docs/python#us_verification_details)
 
 ## Testing
 

--- a/lob/__init__.py
+++ b/lob/__init__.py
@@ -3,6 +3,6 @@ api_base = 'https://api.lob.com/v1'
 
 #Resources
 from lob.resource import (Address, Area, BankAccount, Check, Country,
-        Letter, Postcard, Route, State, Verification)
+        Letter, Postcard, Route, State, USVerification, IntlVerification)
 
 from lob.version import VERSION

--- a/lob/resource.py
+++ b/lob/resource.py
@@ -198,5 +198,8 @@ class Route(ListableAPIResource):
 class State(ListableAPIResource):
     endpoint = '/states'
 
-class Verification(CreateableAPIResource):
-    endpoint = '/verify'
+class USVerification(CreateableAPIResource):
+    endpoint = '/us_verifications'
+
+class IntlVerification(CreateableAPIResource):
+    endpoint = '/intl_verifications'

--- a/tests/test_address.py
+++ b/tests/test_address.py
@@ -48,20 +48,7 @@ class TestAddressFunctions(unittest.TestCase):
     def test_retrieve_address_fail(self):
         self.assertRaises(lob.error.InvalidRequestError, lob.Address.retrieve, id='test')
 
-
     def test_delete_address(self):
         addr = lob.Address.list().data[0].id
         delAddr = lob.Address.delete(id=addr)
         self.assertEqual(addr, delAddr.id)
-
-
-    def test_address_verification(self):
-        addr = lob.Verification.create(
-            address_line1='220 William T Morrissey',
-            address_city='Boston',
-            address_state='MA',
-            address_zip='02125',
-            address_country='US'
-        )
-
-        self.assertEqual(addr.address.address_line1, '220 WILLIAM T MORRISSEY BLVD')

--- a/tests/test_intl_verification.py
+++ b/tests/test_intl_verification.py
@@ -1,0 +1,18 @@
+import unittest
+import lob
+
+class TestIntlVerificationFunctions(unittest.TestCase):
+    def setUp(self):
+        lob.api_key = 'test_fc26575412e92e22a926bc96c857f375f8b'
+
+    def test_intl_verification(self):
+        try:
+            addr = lob.IntlVerification.create(
+                address_line1='370 Water St',
+                address_city='Summerside',
+                address_state='Prince Edward Island',
+                address_zip='C1N 1C4',
+                address_country='CA'
+            )
+        except Exception as e:
+            self.assertEqual(e.http_status, 403)

--- a/tests/test_us_verification.py
+++ b/tests/test_us_verification.py
@@ -1,0 +1,17 @@
+import unittest
+import lob
+
+class TestUSVerificationFunctions(unittest.TestCase):
+    def setUp(self):
+        lob.api_key = 'test_fc26575412e92e22a926bc96c857f375f8b'
+
+    def test_us_verification(self):
+        addr = lob.USVerification.create(
+            primary_line='185 Berry St Ste 6600',
+            city='San Francisco',
+            state='CA',
+            zip_code='94107'
+        )
+
+        self.assertEqual(addr.deliverability, 'deliverable')
+        self.assertEqual(addr.primary_line, '185 BERRY ST STE 6600')


### PR DESCRIPTION
**What**
- [x] Remove deprecated `POST /v1/verify` endpoint
- [x] Add new `POST /v1/us_verifications` endpoint
- [x] Add new `POST /v1/intl_verifications` endpoint