### PR TITLE
chore(py3): copy params before iterating and mutating

### DIFF
--- a/lob/resource.py
+++ b/lob/resource.py
@@ -97,7 +97,7 @@ class APIResource(LobObject):
 class ListableAPIResource(APIResource):
     @classmethod
     def list(cls, **params):
-        for key, value in params.items():
+        for key, value in params.copy().items():
             if isinstance(params[key], dict):
                 for subKey in value:
                     params[str(key) + '[' + subKey + ']'] = value[subKey]


### PR DESCRIPTION
**What**
- [x] Make a copy of `params` in `ListableAPIResource` `list` function before iterating and modifying them.

**Why**
Python2 creates a copy of the dictionary you call `.items()` however Python3 returns an iterator. As such when using Python3, you'll be modifying the same object which you're currently iterating which causes problems (Python3 actually detects this and throws a `RuntimeError`).

Fixes #134 