### PR TITLE
chore(lint): fix most linter warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ examples/**/verified.csv
 
 # Editor files
 *.sublime-*
+
+# macOS
+.DS_Store

--- a/examples/check.py
+++ b/examples/check.py
@@ -1,22 +1,24 @@
-import sys, os
+import sys
+import os
+import lob
 sys.path.insert(0, os.path.abspath(__file__+'../../..'))
 
-import lob
-lob.api_key = "test_fc26575412e92e22a926bc96c857f375f8b" # Replace this API key with your own.
+# Replace this API key with your own.
+lob.api_key = "test_fc26575412e92e22a926bc96c857f375f8b"
 
 # Creating an Address Object
 
 example_address = lob.Address.create(
-    name = 'Joe Smith',
-    description = 'Joe - Home',
-    metadata = {
+    name='Joe Smith',
+    description='Joe - Home',
+    metadata={
         'group': 'Members'
     },
-    address_line1 = '104, Printing Boulevard',
-    address_city = 'Boston',
-    address_state = 'MA',
-    address_country = 'US',
-    address_zip = '12345'
+    address_line1='104, Printing Boulevard',
+    address_city='Boston',
+    address_state='MA',
+    address_country='US',
+    address_zip='12345'
 )
 
 print "\n"
@@ -32,11 +34,11 @@ print "\n"
 # Creating a Bank Account using the previously created account_address
 
 example_bank_account = lob.BankAccount.create(
-    description = 'Example bank account',
-    routing_number = '122100024',
-    account_number = '1234564789',
-    account_type = 'company',
-    signatory = 'John Doe'
+    description='Example bank account',
+    routing_number='122100024',
+    account_number='1234564789',
+    account_type='company',
+    signatory='John Doe'
 )
 
 print "Bank Account Response"
@@ -51,8 +53,8 @@ print "\n"
 # Verifying a Bank Account with the microdeposit amounts
 
 example_bank_account = lob.BankAccount.verify(
-    id = example_bank_account.id,
-    amounts = [23, 77]
+    id=example_bank_account.id,
+    amounts=[23, 77]
 )
 
 print "Bank Account Verify Response"
@@ -67,12 +69,12 @@ print "\n"
 # Creating a Check using the previously created and verified bank account
 
 example_check = lob.Check.create(
-    description = 'Example Check',
-    metadata = {
+    description='Example Check',
+    metadata={
         'FY': '2015'
     },
-    to_address = example_address,
-    from_address = {
+    to_address=example_address,
+    from_address={
         'name': 'Lob',
         'address_line1': '185 Berry Street',
         'address_line2': 'Suite 1510',
@@ -81,10 +83,10 @@ example_check = lob.Check.create(
         'address_zip': '94107',
         'address_country': 'US'
     },
-    bank_account = example_bank_account,
-    amount = 1000,
-    memo = 'Services Rendered',
-    check_bottom = """
+    bank_account=example_bank_account,
+    amount=1000,
+    memo='Services Rendered',
+    check_bottom="""
       <html>
         <head>
           <style>
@@ -96,10 +98,10 @@ example_check = lob.Check.create(
         </head>
         <body><h1>Demo check for {{name}}</h1></body>
       </html>""",
-    merge_variables = {
+    merge_variables={
         'name': example_address.name
     },
-    logo = 'https://s3-us-west-2.amazonaws.com/lob-assets/lob_check_logo.png'
+    logo='https://s3-us-west-2.amazonaws.com/lob-assets/lob_check_logo.png'
 )
 
 print "Check Response"

--- a/examples/create_checks_from_csv/check.py
+++ b/examples/create_checks_from_csv/check.py
@@ -45,7 +45,10 @@ except Exception as e:
     sys.exit(1)
 
 try:
-    example_bank_account = lob.BankAccount.verify(id=bank_account.id, amounts=[23, 77])
+    example_bank_account = lob.BankAccount.verify(
+        id=bank_account.id,
+        amounts=[23, 77]
+    )
 except Exception as e:
     print('Error: ' + str(e))
     print('Failed to verify bank account.')

--- a/examples/letter.py
+++ b/examples/letter.py
@@ -1,22 +1,24 @@
-import sys, os
+import sys
+import os
+import lob
 sys.path.insert(0, os.path.abspath(__file__+'../../..'))
 
-import lob
-lob.api_key = "test_fc26575412e92e22a926bc96c857f375f8b" # Replace this API key with your own.
+# Replace this API key with your own.
+lob.api_key = "test_fc26575412e92e22a926bc96c857f375f8b"
 
 # Creating an Address Object
 
 example_address = lob.Address.create(
-    name = 'Julia Sanchez',
-    description = 'Julia - Home',
-    metadata = {
+    name='Julia Sanchez',
+    description='Julia - Home',
+    metadata={
         'department': 'marketing'
     },
-    address_line1 = '104 Printing Boulevard',
-    address_city = 'Boston',
-    address_state = 'MA',
-    address_country = 'US',
-    address_zip = '12345'
+    address_line1='104 Printing Boulevard',
+    address_city='Boston',
+    address_state='MA',
+    address_country='US',
+    address_zip='12345'
 )
 
 print "\n"
@@ -32,11 +34,11 @@ print "\n"
 # Creating a Letter
 
 example_letter = lob.Letter.create(
-    description = 'Test Letter',
-    metadata = {
+    description='Test Letter',
+    metadata={
         'campaign': 'enterprise offer'
     },
-    to_address = {
+    to_address={
         'name': 'Antoinette Reynolds',
         'address_line1': '1859 Kinney St',
         'address_city': 'Agawam',
@@ -46,8 +48,8 @@ example_letter = lob.Letter.create(
             'customer_type': 'enterprise'
         }
     },
-    from_address = example_address,
-    file = """
+    from_address=example_address,
+    file="""
       <html>
         <head>
           <style>
@@ -59,10 +61,10 @@ example_letter = lob.Letter.create(
         </head>
         <body><h1>Special offer for {{company}}</h1></body>
       </html>""",
-    merge_variables = {
+    merge_variables={
         'company': 'ACME'
     },
-    color = True
+    color=True
 )
 
 print "Letter Response"

--- a/examples/postcard.py
+++ b/examples/postcard.py
@@ -1,22 +1,24 @@
-import sys, os
+import sys
+import os
+import lob
 sys.path.insert(0, os.path.abspath(__file__+'../../..'))
 
-import lob
-lob.api_key = "test_fc26575412e92e22a926bc96c857f375f8b" # Replace this API key with your own.
+# Replace this API key with your own.
+lob.api_key = "test_fc26575412e92e22a926bc96c857f375f8b"
 
 # Creating an Address Object
 
 example_address = lob.Address.create(
-    name = 'Joe Smith',
-    description = 'Joe - Home',
-    metadata = {
+    name='Joe Smith',
+    description='Joe - Home',
+    metadata={
         'group': 'Members'
     },
-    address_line1 = '104, Printing Boulevard',
-    address_city = 'Boston',
-    address_state = 'MA',
-    address_country = 'US',
-    address_zip = '12345'
+    address_line1='104, Printing Boulevard',
+    address_city='Boston',
+    address_state='MA',
+    address_country='US',
+    address_zip='12345'
 )
 
 print "\n"
@@ -32,13 +34,13 @@ print "\n"
 # Creating a Postcard
 
 example_postcard = lob.Postcard.create(
-    description = 'Test Postcard',
-    metadata = {
+    description='Test Postcard',
+    metadata={
         'campaign': 'Member welcome'
     },
-    to_address = example_address,
-    from_address = example_address,
-    front = """
+    to_address=example_address,
+    from_address=example_address,
+    front="""
       <html>
         <head>
           <style>
@@ -50,10 +52,10 @@ example_postcard = lob.Postcard.create(
         </head>
         <body><h1>Hi {{name}}</h1></body>
       </html>""",
-    merge_variables = {
+    merge_variables={
         'name': example_address.name
     },
-    back = "<h1>Welcome to the club!</h1>"
+    back="<h1>Welcome to the club!</h1>"
 )
 
 print "Postcard Response"

--- a/examples/verify_addresses_from_csv/verify.py
+++ b/examples/verify_addresses_from_csv/verify.py
@@ -29,7 +29,7 @@ verifications_csv_fields = [
     'deliverability'
 ]
 
-#create the output directory,
+# create the output directory,
 output_dir = os.path.join('.',  'output')
 if not os.path.isdir(output_dir):
     os.mkdir(output_dir)
@@ -49,7 +49,7 @@ verifications_filename = os.path.join(output_dir, 'verifications.csv')
 
 try:
     with open(input_filename, 'r') as input, \
-        open(verifications_filename, 'w') as verifications:
+         open(verifications_filename, 'w') as verifications:
 
         input_csv = csv.DictReader(input)
 

--- a/lob/__init__.py
+++ b/lob/__init__.py
@@ -1,8 +1,8 @@
-api_key = None
-api_base = 'https://api.lob.com/v1'
-
-#Resources
-from lob.resource import (Address, Area, BankAccount, Check,
-        Letter, Postcard, Route, USVerification, USZipLookup, IntlVerification)
+# Resources
+from lob.resource import (Address, Area, BankAccount, Check, Letter, Postcard,
+                          Route, USVerification, USZipLookup, IntlVerification)
 
 from lob.version import VERSION
+
+api_key = None
+api_base = 'https://api.lob.com/v1'

--- a/lob/api_requestor.py
+++ b/lob/api_requestor.py
@@ -23,21 +23,20 @@ class APIRequestor(object):
 
     def parse_response(self, resp):
         if resp.status_code == 504:
-            raise error.APIConnectionError(resp.content or resp.reason, # pragma: no cover
-                resp.content, resp.status_code, resp)
+            raise error.APIConnectionError(resp.content or resp.reason,  # pragma: no cover
+                                           resp.content, resp.status_code, resp)
 
         payload = resp.json()
         if resp.status_code == 200:
             return payload
         elif resp.status_code == 401:
             raise error.AuthenticationError(payload['error']['message'],
-                resp.content, resp.status_code, resp)
+                                            resp.content, resp.status_code, resp)
         elif resp.status_code in [404, 422]:
             raise error.InvalidRequestError(payload['error']['message'],
-                resp.content, resp.status_code, resp)
-        else: # pragma: no cover
+                                            resp.content, resp.status_code, resp)
+        else:  # pragma: no cover
             raise error.APIError(payload['error']['message'], resp.content, resp.status_code, resp)
-
 
     def request(self, method, url, params=None):
         headers = {
@@ -64,14 +63,14 @@ class APIRequestor(object):
             files = params.pop('files', {})
             explodedParams = {}
 
-            for k,v in params.items():
+            for k, v in params.items():
                 if isinstance(v, dict) and not isinstance(v, lob.resource.LobObject):
-                    for k2,v2 in v.items():
+                    for k2, v2 in v.items():
                         explodedParams[k + '[' + k2 + ']'] = v2
                 else:
                     explodedParams[k] = v
 
-            for k,v in explodedParams.items():
+            for k, v in explodedParams.items():
                 if _is_file_like(v):
                     files[k] = v
                 else:

--- a/lob/error.py
+++ b/lob/error.py
@@ -4,20 +4,24 @@ from __future__ import unicode_literals
 class LobError(Exception):
 
     def __init__(self, message=None, http_body=None, http_status=None,
-        json_body=None):
+                 json_body=None):
         super(LobError, self).__init__(message)
         self.http_body = http_body
         self.http_status = http_status
         self.json_body = json_body
 
+
 class APIError(LobError):
     pass
+
 
 class APIConnectionError(LobError):
     pass
 
+
 class AuthenticationError(LobError):
     pass
+
 
 class InvalidRequestError(LobError):
     pass

--- a/lob/resource.py
+++ b/lob/resource.py
@@ -3,7 +3,6 @@ from __future__ import unicode_literals
 import json
 
 from lob import api_requestor
-from lob import error
 from lob.compat import string_type
 
 
@@ -13,11 +12,11 @@ def lob_format(resp):
         'area': Area,
         'bank_account': BankAccount,
         'check': Check,
-        'letter' : Letter,
+        'letter': Letter,
         'postcard': Postcard
     }
 
-    #Change Keys for To/From
+    # Change Keys for To/From
     if isinstance(resp, dict) and 'to' in resp:
         resp['to_address'] = resp['to']
         resp.pop('to', None)
@@ -25,7 +24,7 @@ def lob_format(resp):
         resp['from_address'] = resp['from']
         resp.pop('from', None)
 
-    #Recursively Set Objects for Lists
+    # Recursively Set Objects for Lists
     if isinstance(resp, dict) and 'object' in resp and resp['object'] == 'list':
         resp['data'] = [lob_format(i) for i in resp['data']]
         return LobObject.construct_from(resp)
@@ -36,13 +35,14 @@ def lob_format(resp):
         else:
             klass = LobObject
 
-        #Check For Arrays
+        # Check For Arrays
         for key in resp:
             if isinstance(resp[key], list):
                 resp[key] = [lob_format(i) for i in resp[key]]
         return klass.construct_from(resp)
     else:
         return resp
+
 
 class LobObject(dict):
 
@@ -62,7 +62,7 @@ class LobObject(dict):
         try:
             return self[k]
         except KeyError:
-            raise AttributeError(k) #pragma: no cover
+            raise AttributeError(k)  # pragma: no cover
 
     def __setattr__(self, k, v):
         self[k] = v
@@ -84,12 +84,14 @@ class LobObject(dict):
     def __str__(self):
         return json.dumps(self, sort_keys=True, indent=2)
 
+
 class APIResource(LobObject):
     @classmethod
     def retrieve(cls, id, **params):
         requestor = api_requestor.APIRequestor()
         response = requestor.request('get', '%s/%s' % (cls.endpoint, id), params)
         return lob_format(response)
+
 
 # API Operations
 class ListableAPIResource(APIResource):
@@ -107,12 +109,14 @@ class ListableAPIResource(APIResource):
         response = requestor.request('get', cls.endpoint, params)
         return lob_format(response)
 
+
 class DeleteableAPIResource(APIResource):
     @classmethod
     def delete(cls, id):
         requestor = api_requestor.APIRequestor()
         response = requestor.request('delete', '%s/%s' % (cls.endpoint, id))
         return lob_format(response)
+
 
 class CreateableAPIResource(APIResource):
     @classmethod
@@ -121,6 +125,7 @@ class CreateableAPIResource(APIResource):
         response = requestor.request('post', cls.endpoint, params)
         return lob_format(response)
 
+
 class VerifiableAPIResource(APIResource):
     @classmethod
     def verify(cls, id, **params):
@@ -128,11 +133,14 @@ class VerifiableAPIResource(APIResource):
         response = requestor.request('post', '%s/%s/verify' % (cls.endpoint, id), params)
         return lob_format(response)
 
+
 class Address(ListableAPIResource, DeleteableAPIResource, CreateableAPIResource):
     endpoint = '/addresses'
 
+
 class Area(ListableAPIResource, CreateableAPIResource):
     endpoint = '/areas'
+
     @classmethod
     def create(cls, **params):
         if isinstance(params, dict):
@@ -144,11 +152,14 @@ class Area(ListableAPIResource, CreateableAPIResource):
                     params['routes'] = routes
         return super(Area, cls).create(**params)
 
+
 class BankAccount(ListableAPIResource, DeleteableAPIResource, CreateableAPIResource, VerifiableAPIResource):
     endpoint = '/bank_accounts'
 
+
 class Check(ListableAPIResource, CreateableAPIResource, DeleteableAPIResource):
     endpoint = '/checks'
+
     @classmethod
     def create(cls, **params):
         if isinstance(params, dict):
@@ -160,8 +171,10 @@ class Check(ListableAPIResource, CreateableAPIResource, DeleteableAPIResource):
                 params.pop('from_address')
         return super(Check, cls).create(**params)
 
+
 class Letter(ListableAPIResource, CreateableAPIResource, DeleteableAPIResource):
     endpoint = '/letters'
+
     @classmethod
     def create(cls, **params):
         if isinstance(params, dict):
@@ -173,8 +186,10 @@ class Letter(ListableAPIResource, CreateableAPIResource, DeleteableAPIResource):
                 params.pop('to_address')
         return super(Letter, cls).create(**params)
 
+
 class Postcard(ListableAPIResource, CreateableAPIResource, DeleteableAPIResource):
     endpoint = '/postcards'
+
     @classmethod
     def create(cls, **params):
         if isinstance(params, dict):
@@ -186,14 +201,18 @@ class Postcard(ListableAPIResource, CreateableAPIResource, DeleteableAPIResource
                 params.pop('to_address')
         return super(Postcard, cls).create(**params)
 
+
 class Route(ListableAPIResource):
     endpoint = '/routes'
+
 
 class USVerification(CreateableAPIResource):
     endpoint = '/us_verifications'
 
+
 class USZipLookup(CreateableAPIResource):
     endpoint = '/us_zip_lookups'
+
 
 class IntlVerification(CreateableAPIResource):
     endpoint = '/intl_verifications'

--- a/setup.py
+++ b/setup.py
@@ -1,33 +1,31 @@
-import sys
-import os
 try:
     from setuptools import setup
 except ImportError:
     from disutils.core import setup
 
-setup (
-        name = 'lob',
-        version = '3.1.3',
-        author = 'Lob',
-        author_email = 'support@lob.com',
-        packages = ['lob'],
-        description = 'Lob Python Bindings',
-        url = 'https://www.lob.com',
-        license = 'MIT',
-        install_requires = [
-            'requests'
-            ],
-        classifiers=[
-            "Development Status :: 5 - Production/Stable",
-            "License :: OSI Approved :: MIT License",
-            "Programming Language :: Python",
-            "Programming Language :: Python :: 2.6",
-            "Programming Language :: Python :: 2.7",
-            "Programming Language :: Python :: 3",
-            "Programming Language :: Python :: 3.3",
-            "Programming Language :: Python :: 3.4",
-            "Programming Language :: Python :: 3.5",
-            "Programming Language :: Python :: Implementation :: CPython",
-            "Programming Language :: Python :: Implementation :: PyPy"
-        ]
-      )
+setup(
+    name='lob',
+    version='3.1.3',
+    author='Lob',
+    author_email='support@lob.com',
+    packages=['lob'],
+    description='Lob Python Bindings',
+    url='https://www.lob.com',
+    license='MIT',
+    install_requires=[
+        'requests'
+        ],
+    classifiers=[
+        "Development Status :: 5 - Production/Stable",
+        "License :: OSI Approved :: MIT License",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 2.6",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.3",
+        "Programming Language :: Python :: 3.4",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: Implementation :: CPython",
+        "Programming Language :: Python :: Implementation :: PyPy"
+    ]
+)

--- a/tests/test_address.py
+++ b/tests/test_address.py
@@ -1,6 +1,7 @@
 import unittest
 import lob
 
+
 class TestAddressFunctions(unittest.TestCase):
     def setUp(self):
         lob.api_key = 'test_fc26575412e92e22a926bc96c857f375f8b'

--- a/tests/test_area.py
+++ b/tests/test_area.py
@@ -1,6 +1,7 @@
 import unittest
 import lob
 
+
 class AreaFunctions(unittest.TestCase):
     def setUp(self):
         lob.api_key = 'test_fc26575412e92e22a926bc96c857f375f8b'
@@ -8,33 +9,31 @@ class AreaFunctions(unittest.TestCase):
 
     def test_create_area_with_zip(self):
         area = lob.Area.create(
-            description = 'area_test_zip',
-            front = '<h1>Hi</h1>',
-            back = '<h1>Goodbye</h1>',
-            routes = ['94158','60031'],
-            target_type = 'all'
+            description='area_test_zip',
+            front='<h1>Hi</h1>',
+            back='<h1>Goodbye</h1>',
+            routes=['94158', '60031'],
+            target_type='all'
         )
         self.assertTrue(isinstance(area, lob.Area))
-
 
     def test_create_area_with_route(self):
         area = lob.Area.create(
-            description = 'area_test_route',
-            front = '<h1>Hi</h1>',
-            back = '<h1>Goodbye</h1>',
-            routes = self.route,
-            target_type = 'all'
+            description='area_test_route',
+            front='<h1>Hi</h1>',
+            back='<h1>Goodbye</h1>',
+            routes=self.route,
+            target_type='all'
         )
         self.assertTrue(isinstance(area, lob.Area))
 
-
     def test_create_area_local_file(self):
         area = lob.Area.create(
-            description = 'area_local_file',
-            front = open('tests/areafront.pdf', 'rb'),
-            back = open('tests/areaback.pdf', 'rb'),
-            routes = self.route,
-            target_type = 'all'
+            description='area_local_file',
+            front=open('tests/areafront.pdf', 'rb'),
+            back=open('tests/areaback.pdf', 'rb'),
+            routes=self.route,
+            target_type='all'
         )
         self.assertTrue(isinstance(area, lob.Area))
 

--- a/tests/test_bankaccount.py
+++ b/tests/test_bankaccount.py
@@ -1,6 +1,7 @@
 import unittest
 import lob
 
+
 class BankAccountFunctions(unittest.TestCase):
     def setUp(self):
         lob.api_key = 'test_fc26575412e92e22a926bc96c857f375f8b'
@@ -26,7 +27,7 @@ class BankAccountFunctions(unittest.TestCase):
         bankAccount = lob.BankAccount.create(
             routing_number='122100024',
             account_number='123456789',
-            account_type = 'company',
+            account_type='company',
             signatory='John Doe'
         )
         self.assertTrue(isinstance(bankAccount, lob.BankAccount))
@@ -47,7 +48,7 @@ class BankAccountFunctions(unittest.TestCase):
         ba = lob.BankAccount.create(
             routing_number='122100024',
             account_number='223456789',
-            account_type = 'company',
+            account_type='company',
             signatory='John Doe'
         )
         verBa = lob.BankAccount.verify(id=ba.id, amounts=[25, 75])

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -1,15 +1,16 @@
 import lob
 import unittest
 
+
 class CheckFunctions(unittest.TestCase):
     def setUp(self):
         lob.api_key = 'test_fc26575412e92e22a926bc96c857f375f8b'
         self.addr = lob.Address.list(limit=1).data[0]
         self.ba = lob.BankAccount.create(
-            routing_number = '122100024',
-            account_number = '123456789',
-            account_type = 'company',
-            signatory = 'John Doe'
+            routing_number='122100024',
+            account_number='123456789',
+            account_type='company',
+            signatory='John Doe'
         )
         lob.BankAccount.verify(id=self.ba.id, amounts=[20, 80])
 
@@ -28,12 +29,12 @@ class CheckFunctions(unittest.TestCase):
 
     def test_create_check(self):
         check = lob.Check.create(
-            description = 'Test Check',
-            bank_account = self.ba.id,
-            to_address = self.addr.id,
-            from_address = self.addr.id,
-            amount = 1000,
-            memo = 'Test Check'
+            description='Test Check',
+            bank_account=self.ba.id,
+            to_address=self.addr.id,
+            from_address=self.addr.id,
+            amount=1000,
+            memo='Test Check'
         )
 
         self.assertTrue(isinstance(check, lob.Check))
@@ -43,9 +44,9 @@ class CheckFunctions(unittest.TestCase):
 
     def test_create_check_inline(self):
         check = lob.Check.create(
-            description = 'Test Check',
-            bank_account = self.ba,
-            to_address = {
+            description='Test Check',
+            bank_account=self.ba,
+            to_address={
                 'name': 'Lob',
                 'address_line1': '185 Berry Street',
                 'address_line2': 'Suite 1510',
@@ -53,7 +54,7 @@ class CheckFunctions(unittest.TestCase):
                 'address_zip': '94107',
                 'address_state': 'CA'
             },
-            from_address = {
+            from_address={
                 'name': 'Lob',
                 'address_line1': '185 Berry Street',
                 'address_line2': 'Suite 1510',
@@ -61,8 +62,8 @@ class CheckFunctions(unittest.TestCase):
                 'address_zip': '94107',
                 'address_state': 'CA'
             },
-            amount = 1000,
-            memo = 'Test Check'
+            amount=1000,
+            memo='Test Check'
         )
 
         self.assertTrue(isinstance(check, lob.Check))
@@ -72,14 +73,14 @@ class CheckFunctions(unittest.TestCase):
 
     def test_delete_postcard(self):
         check = lob.Check.create(
-            description = 'Test Check',
-            bank_account = self.ba.id,
-            to_address = self.addr.id,
-            from_address = self.addr.id,
-            amount = 1000,
-            memo = 'Test Check'
+            description='Test Check',
+            bank_account=self.ba.id,
+            to_address=self.addr.id,
+            from_address=self.addr.id,
+            amount=1000,
+            memo='Test Check'
         )
-        deleted_response = lob.Check.delete(check.id);
+        deleted_response = lob.Check.delete(check.id)
         self.assertTrue(deleted_response.deleted)
 
     def test_create_check_fail(self):

--- a/tests/test_intl_verification.py
+++ b/tests/test_intl_verification.py
@@ -1,13 +1,14 @@
 import unittest
 import lob
 
+
 class TestIntlVerificationFunctions(unittest.TestCase):
     def setUp(self):
         lob.api_key = 'test_fc26575412e92e22a926bc96c857f375f8b'
 
     def test_intl_verification(self):
         try:
-            addr = lob.IntlVerification.create(
+            lob.IntlVerification.create(
                 primary_line='370 Water St',
                 city='Summerside',
                 state='Prince Edward Island',

--- a/tests/test_letter.py
+++ b/tests/test_letter.py
@@ -1,6 +1,7 @@
 import unittest
 import lob
 
+
 class LetterFunctions(unittest.TestCase):
     def setUp(self):
         lob.api_key = 'test_fc26575412e92e22a926bc96c857f375f8b'
@@ -17,38 +18,38 @@ class LetterFunctions(unittest.TestCase):
 
     def test_create_letter(self):
         letter = lob.Letter.create(
-            from_address = {
+            from_address={
                 'name': 'Antoinette Reynolds',
                 'address_line1': '1859 Kinney St',
                 'address_city': 'Agawam',
                 'address_zip': '01001',
                 'address_state': 'MA'
             },
-            to_address = self.addr.id,
-            file = '<h1>{{name}}</h1>',
-            merge_variables = {
+            to_address=self.addr.id,
+            file='<h1>{{name}}</h1>',
+            merge_variables={
                 'name': 'Peter'
             },
-            color = True
+            color=True
         )
         self.assertEqual(letter.to_address.id, self.addr.id)
         self.assertTrue(isinstance(letter, lob.Letter))
 
     def test_delete_letter(self):
         letter = lob.Letter.create(
-            from_address = {
+            from_address={
                 'name': 'Antoinette Reynolds',
                 'address_line1': '1859 Kinney St',
                 'address_city': 'Agawam',
                 'address_zip': '01001',
                 'address_state': 'MA'
             },
-            to_address = self.addr.id,
-            file = '<h1>{{name}}</h1>',
-            merge_variables = {
+            to_address=self.addr.id,
+            file='<h1>{{name}}</h1>',
+            merge_variables={
                 'name': 'Peter'
             },
-            color = True
+            color=True
         )
-        deleted_response = lob.Letter.delete(letter.id);
+        deleted_response = lob.Letter.delete(letter.id)
         self.assertTrue(deleted_response.deleted)

--- a/tests/test_lob.py
+++ b/tests/test_lob.py
@@ -1,6 +1,7 @@
 import unittest
 import lob
 
+
 class TestLob(unittest.TestCase):
     def setUp(self):
         lob.api_key = 'asdf'

--- a/tests/test_postcard.py
+++ b/tests/test_postcard.py
@@ -1,6 +1,7 @@
 import unittest
 import lob
 
+
 class PostcardFunctions(unittest.TestCase):
     def setUp(self):
         lob.api_key = 'test_fc26575412e92e22a926bc96c857f375f8b'
@@ -17,7 +18,7 @@ class PostcardFunctions(unittest.TestCase):
         self.assertEqual(len(postcards.data), 2)
 
     def test_list_postcards_metadata(self):
-        postcards = lob.Postcard.list(metadata={ 'campagin': 'LOB2015' })
+        postcards = lob.Postcard.list(metadata={'campagin': 'LOB2015'})
         self.assertTrue(isinstance(postcards.data[0], lob.Postcard))
         self.assertEqual(len(postcards.data), 1)
 
@@ -26,11 +27,11 @@ class PostcardFunctions(unittest.TestCase):
 
     def test_create_postcard(self):
         postcard = lob.Postcard.create(
-            to_address = self.addr.id,
-            from_address = self.addr.id,
-            front = '<h1>{{front_name}}</h1>',
-            back = '<h1>{{back_name}}</h1>',
-            merge_variables = {
+            to_address=self.addr.id,
+            from_address=self.addr.id,
+            front='<h1>{{front_name}}</h1>',
+            back='<h1>{{back_name}}</h1>',
+            merge_variables={
                 'front_name': 'Peter',
                 'back_name': 'Otto'
             }
@@ -42,19 +43,19 @@ class PostcardFunctions(unittest.TestCase):
     def test_create_idempotent_postcards(self):
         idempotency_key = "Test_Idempotency_Key"
         postcard_one = lob.Postcard.create(
-            to_address = self.addr.id,
-            front = '<h1>Front</h1>',
-            back = '<h1>Back</h1>',
-            headers = {
+            to_address=self.addr.id,
+            front='<h1>Front</h1>',
+            back='<h1>Back</h1>',
+            headers={
                 'Idempotency-Key': idempotency_key
             }
         )
 
         postcard_two = lob.Postcard.create(
-            to_address = self.addr.id,
-            front = '<h1>Front</h1>',
-            back = '<h1>Back</h1>',
-            headers = {
+            to_address=self.addr.id,
+            front='<h1>Front</h1>',
+            back='<h1>Back</h1>',
+            headers={
                 'Idempotency-Key': idempotency_key
             }
         )
@@ -64,11 +65,11 @@ class PostcardFunctions(unittest.TestCase):
 
     def test_create_postcard_lob_obj(self):
         postcard = lob.Postcard.create(
-            to_address = self.addr,
-            from_address = self.addr,
-            front = '<h1>{{front_name}}</h1>',
-            back = '<h1>{{back_name}}</h1>',
-            merge_variables = {
+            to_address=self.addr,
+            from_address=self.addr,
+            front='<h1>{{front_name}}</h1>',
+            back='<h1>{{back_name}}</h1>',
+            merge_variables={
                 'front_name': 'Peter',
                 'back_name': 'Otto'
             }
@@ -79,7 +80,7 @@ class PostcardFunctions(unittest.TestCase):
 
     def test_create_postcard_inline(self):
         postcard = lob.Postcard.create(
-            to_address = {
+            to_address={
                 'name': 'Lob1',
                 'address_line1': '185 Berry Street',
                 'address_line2': 'Suite 1510',
@@ -87,7 +88,7 @@ class PostcardFunctions(unittest.TestCase):
                 'address_zip': '94107',
                 'address_state': 'CA'
             },
-            from_address = {
+            from_address={
                 'name': 'Lob2',
                 'address_line1': '185 Berry Street',
                 'address_line2': 'Suite 1510',
@@ -95,9 +96,9 @@ class PostcardFunctions(unittest.TestCase):
                 'address_zip': '94107',
                 'address_state': 'CA'
             },
-            front = '<h1>{{front_name}}</h1>',
-            back = '<h1>{{back_name}}</h1>',
-            merge_variables = {
+            front='<h1>{{front_name}}</h1>',
+            back='<h1>{{back_name}}</h1>',
+            merge_variables={
                 'front_name': 'Peter',
                 'back_name': 'Otto'
             }
@@ -108,21 +109,21 @@ class PostcardFunctions(unittest.TestCase):
 
     def test_create_postcard_local_file(self):
         postcard = lob.Postcard.create(
-            to_address = self.addr.id,
-            from_address = self.addr.id,
-            front = open('tests/pc.pdf', 'rb'),
-            back = open('tests/pc.pdf', 'rb')
+            to_address=self.addr.id,
+            from_address=self.addr.id,
+            front=open('tests/pc.pdf', 'rb'),
+            back=open('tests/pc.pdf', 'rb')
         )
         self.assertTrue(isinstance(postcard, lob.Postcard))
 
     def test_delete_postcard(self):
         postcard = lob.Postcard.create(
-            to_address = self.addr.id,
-            from_address = self.addr.id,
-            front = open('tests/pc.pdf', 'rb'),
-            back = open('tests/pc.pdf', 'rb')
+            to_address=self.addr.id,
+            from_address=self.addr.id,
+            front=open('tests/pc.pdf', 'rb'),
+            back=open('tests/pc.pdf', 'rb')
         )
-        deleted_response = lob.Postcard.delete(postcard.id);
+        deleted_response = lob.Postcard.delete(postcard.id)
         self.assertTrue(deleted_response.deleted)
 
     def test_create_postcard_fail(self):

--- a/tests/test_route.py
+++ b/tests/test_route.py
@@ -3,9 +3,10 @@ from __future__ import print_function
 import unittest
 import lob
 
+
 class RouteTest(unittest.TestCase):
     def setUp(self):
         lob.api_key = 'test_fc26575412e92e22a926bc96c857f375f8b'
 
     def test_route_find(self):
-        print(lob.Route.list(zip_codes=[94158,60031]))
+        print(lob.Route.list(zip_codes=[94158, 60031]))

--- a/tests/test_us_verification.py
+++ b/tests/test_us_verification.py
@@ -1,6 +1,7 @@
 import unittest
 import lob
 
+
 class TestUSVerificationFunctions(unittest.TestCase):
     def setUp(self):
         lob.api_key = 'test_fc26575412e92e22a926bc96c857f375f8b'

--- a/tests/test_us_zip_lookup.py
+++ b/tests/test_us_zip_lookup.py
@@ -1,6 +1,7 @@
 import unittest
 import lob
 
+
 class TestUSZipLookupFunctions(unittest.TestCase):
     def setUp(self):
         lob.api_key = 'test_fc26575412e92e22a926bc96c857f375f8b'


### PR DESCRIPTION
## What
Fixes most linter warnings other than "imported but unused" errors in `__init__.py` and "line too long" errors. 

## Why
We should be following the pep8 style guide as much as possible. If we want to adhere to the line character limit, I'll fix that up too. 