### PR TITLE
fix(tests): remove code support for deprecated endpoint

### DIFF
--- a/lob/api_requestor.py
+++ b/lob/api_requestor.py
@@ -78,11 +78,7 @@ class APIRequestor(object):
                     if isinstance(v, lob.resource.LobObject):
                         data[k] = v.id
                     else:
-                        if isinstance(v, dict):
-                            for k2, v2 in v.items():
-                                data[k + '[' + k2 + ']'] = v2
-                        else:
-                            data[k] = v
+                        data[k] = v
 
             return self.parse_response(
                 requests.post(lob.api_base + url, auth=(self.api_key, ''), data=data, files=files, headers=headers)

--- a/lob/resource.py
+++ b/lob/resource.py
@@ -64,9 +64,6 @@ class LobObject(dict):
         except KeyError:
             raise AttributeError(k) #pragma: no cover
 
-    def __setattr__(self, k, v):
-        self[k] = v
-
     def __repr__(self):
         ident_parts = [type(self).__name__]
 


### PR DESCRIPTION
## What
Removes code that was used to support parameters from a [deprecated endpoint](https://github.com/lob/lob-python/pull/121).

## Why
We shouldn't have useless code lying around.