### PR TITLE
feat(CreateableResource): allow query params in creatable resources

### DIFF
--- a/lob/api_requestor.py
+++ b/lob/api_requestor.py
@@ -59,9 +59,14 @@ class APIRequestor(object):
                 requests.delete(lob.api_base + url, auth=(self.api_key, ''), headers=headers)
             )
         elif method == 'post':
+            query = {}
             data = {}
             files = params.pop('files', {})
             explodedParams = {}
+
+            if params and 'query' in params:
+                query.update(params['query'])
+                del params['query']
 
             for k, v in params.items():
                 if isinstance(v, dict) and not isinstance(v, lob.resource.LobObject):
@@ -80,5 +85,5 @@ class APIRequestor(object):
                         data[k] = v
 
             return self.parse_response(
-                requests.post(lob.api_base + url, auth=(self.api_key, ''), data=data, files=files, headers=headers)
+                requests.post(lob.api_base + url, auth=(self.api_key, ''), params=query, data=data, files=files, headers=headers)
             )

--- a/tests/test_us_verification.py
+++ b/tests/test_us_verification.py
@@ -8,11 +8,25 @@ class TestUSVerificationFunctions(unittest.TestCase):
 
     def test_us_verification(self):
         addr = lob.USVerification.create(
-            primary_line='185 Berry St Ste 6600',
+            primary_line='deliverable',
             city='San Francisco',
             state='CA',
             zip_code='94107'
         )
 
         self.assertEqual(addr.deliverability, 'deliverable')
-        self.assertEqual(addr.primary_line, '185 BERRY ST STE 6600')
+        self.assertEqual(addr.primary_line, '1 TELEGRAPH HILL BLVD')
+
+    def test_us_verification_format(self):
+        addr = lob.USVerification.create(
+            primary_line='deliverable',
+            city='San Francisco',
+            state='CA',
+            zip_code='94107',
+            query={
+                'case': 'proper'
+            }
+        )
+
+        self.assertEqual(addr.deliverability, 'deliverable')
+        self.assertEqual(addr.primary_line, '1 Telegraph Hill Blvd')


### PR DESCRIPTION
**What** 
- Allow us to send a `query` values with CreateableAPIResources.
- Minor code cleanup (deleting unnecessary new lines)
