### PR TITLE
test(api-key): remove lob api key from tests and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ There are simple scripts to demonstrate how to create all the core Lob objects (
 
 Install all requirements with `pip install -r requirements.txt`.
 
-You can run all tests with the command `nosetests` in the main directory.
+You can run all tests with the command `LOB_API_KEY=YOUR_TEST_API_KEY nosetests` in the main directory.
 
 =======================
 

--- a/examples/check.py
+++ b/examples/check.py
@@ -4,7 +4,7 @@ import lob
 sys.path.insert(0, os.path.abspath(__file__+'../../..'))
 
 # Replace this API key with your own.
-lob.api_key = "test_fc26575412e92e22a926bc96c857f375f8b"
+lob.api_key = ''
 
 # Creating an Address Object
 

--- a/examples/check.py
+++ b/examples/check.py
@@ -4,7 +4,7 @@ import lob
 sys.path.insert(0, os.path.abspath(__file__+'../../..'))
 
 # Replace this API key with your own.
-lob.api_key = ''
+lob.api_key = 'YOUR_API_KEY'
 
 # Creating an Address Object
 

--- a/examples/create_checks_from_csv/check.py
+++ b/examples/create_checks_from_csv/check.py
@@ -12,7 +12,7 @@ sys.path.insert(0, os.path.abspath(__file__+'../../..'))
 
 ###########################################################
 # TODO: Provide your API Key, keep this secure
-lob.api_key = ''
+lob.api_key = 'YOUR_API_KEY'
 
 # TODO: Create your from_address
 try:

--- a/examples/create_checks_from_csv/check.py
+++ b/examples/create_checks_from_csv/check.py
@@ -12,7 +12,7 @@ sys.path.insert(0, os.path.abspath(__file__+'../../..'))
 
 ###########################################################
 # TODO: Provide your API Key, keep this secure
-lob.api_key = 'test_fc26575412e92e22a926bc96c857f375f8b'
+lob.api_key = ''
 
 # TODO: Create your from_address
 try:

--- a/examples/create_letters_from_csv/letters.py
+++ b/examples/create_letters_from_csv/letters.py
@@ -12,7 +12,7 @@ sys.path.insert(0, os.path.abspath(__file__+'../../..'))
 
 ###########################################################
 # TODO: Provide your API Key, keep this secure
-lob.api_key = ''
+lob.api_key = 'YOUR_API_KEY'
 
 # TODO: Create your from_address
 try:

--- a/examples/create_letters_from_csv/letters.py
+++ b/examples/create_letters_from_csv/letters.py
@@ -12,7 +12,7 @@ sys.path.insert(0, os.path.abspath(__file__+'../../..'))
 
 ###########################################################
 # TODO: Provide your API Key, keep this secure
-lob.api_key = 'test_fc26575412e92e22a926bc96c857f375f8b'
+lob.api_key = ''
 
 # TODO: Create your from_address
 try:

--- a/examples/create_postcards_from_csv/postcards.py
+++ b/examples/create_postcards_from_csv/postcards.py
@@ -12,7 +12,7 @@ sys.path.insert(0, os.path.abspath(__file__+'../../..'))
 
 ###########################################################
 # TODO: Provide your API Key, keep this secure
-lob.api_key = ''
+lob.api_key = 'YOUR_API_KEY'
 
 # TODO: Create your from_address
 try:

--- a/examples/create_postcards_from_csv/postcards.py
+++ b/examples/create_postcards_from_csv/postcards.py
@@ -12,7 +12,7 @@ sys.path.insert(0, os.path.abspath(__file__+'../../..'))
 
 ###########################################################
 # TODO: Provide your API Key, keep this secure
-lob.api_key = 'test_fc26575412e92e22a926bc96c857f375f8b'
+lob.api_key = ''
 
 # TODO: Create your from_address
 try:

--- a/examples/letter.py
+++ b/examples/letter.py
@@ -4,7 +4,7 @@ import lob
 sys.path.insert(0, os.path.abspath(__file__+'../../..'))
 
 # Replace this API key with your own.
-lob.api_key = "test_fc26575412e92e22a926bc96c857f375f8b"
+lob.api_key = ''
 
 # Creating an Address Object
 

--- a/examples/letter.py
+++ b/examples/letter.py
@@ -4,7 +4,7 @@ import lob
 sys.path.insert(0, os.path.abspath(__file__+'../../..'))
 
 # Replace this API key with your own.
-lob.api_key = ''
+lob.api_key = 'YOUR_API_KEY'
 
 # Creating an Address Object
 

--- a/examples/postcard.py
+++ b/examples/postcard.py
@@ -4,7 +4,7 @@ import lob
 sys.path.insert(0, os.path.abspath(__file__+'../../..'))
 
 # Replace this API key with your own.
-lob.api_key = "test_fc26575412e92e22a926bc96c857f375f8b"
+lob.api_key = ''
 
 # Creating an Address Object
 

--- a/examples/postcard.py
+++ b/examples/postcard.py
@@ -4,7 +4,7 @@ import lob
 sys.path.insert(0, os.path.abspath(__file__+'../../..'))
 
 # Replace this API key with your own.
-lob.api_key = ''
+lob.api_key = 'YOUR_API_KEY'
 
 # Creating an Address Object
 

--- a/examples/verify_addresses_from_csv/verify.py
+++ b/examples/verify_addresses_from_csv/verify.py
@@ -11,7 +11,7 @@ import sys
 sys.path.insert(0, os.path.abspath(__file__+'../../../..'))
 
 # TODO: Provide your API key, keep this secure
-lob.api_key = ''
+lob.api_key = 'YOUR_API_KEY'
 
 # Input check
 if len(sys.argv) < 2:

--- a/examples/verify_addresses_from_csv/verify.py
+++ b/examples/verify_addresses_from_csv/verify.py
@@ -11,7 +11,7 @@ import sys
 sys.path.insert(0, os.path.abspath(__file__+'../../../..'))
 
 # TODO: Provide your API key, keep this secure
-lob.api_key = 'test_fc26575412e92e22a926bc96c857f375f8b'
+lob.api_key = ''
 
 # Input check
 if len(sys.argv) < 2:

--- a/tests/test_address.py
+++ b/tests/test_address.py
@@ -1,10 +1,11 @@
 import unittest
+import os
 import lob
 
 
 class TestAddressFunctions(unittest.TestCase):
     def setUp(self):
-        lob.api_key = 'test_fc26575412e92e22a926bc96c857f375f8b'
+        lob.api_key = os.environ.get('LOB_API_KEY')
 
     def test_list_addresses(self):
         addresses = lob.Address.list()

--- a/tests/test_bankaccount.py
+++ b/tests/test_bankaccount.py
@@ -1,10 +1,11 @@
 import unittest
+import os
 import lob
 
 
 class BankAccountFunctions(unittest.TestCase):
     def setUp(self):
-        lob.api_key = 'test_fc26575412e92e22a926bc96c857f375f8b'
+        lob.api_key = os.environ.get('LOB_API_KEY')
         self.addr = lob.Address.list(limit=1).data[0]
 
     def test_list_bankAccounts(self):

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -1,10 +1,11 @@
 import lob
+import os
 import unittest
 
 
 class CheckFunctions(unittest.TestCase):
     def setUp(self):
-        lob.api_key = 'test_fc26575412e92e22a926bc96c857f375f8b'
+        lob.api_key = os.environ.get('LOB_API_KEY')
         self.addr = lob.Address.list(limit=1).data[0]
         self.ba = lob.BankAccount.create(
             routing_number='122100024',

--- a/tests/test_intl_verification.py
+++ b/tests/test_intl_verification.py
@@ -1,10 +1,11 @@
 import unittest
+import os
 import lob
 
 
 class TestIntlVerificationFunctions(unittest.TestCase):
     def setUp(self):
-        lob.api_key = 'test_fc26575412e92e22a926bc96c857f375f8b'
+        lob.api_key = os.environ.get('LOB_API_KEY')
 
     def test_intl_verification(self):
         try:

--- a/tests/test_letter.py
+++ b/tests/test_letter.py
@@ -1,10 +1,11 @@
 import unittest
+import os
 import lob
 
 
 class LetterFunctions(unittest.TestCase):
     def setUp(self):
-        lob.api_key = 'test_fc26575412e92e22a926bc96c857f375f8b'
+        lob.api_key = os.environ.get('LOB_API_KEY')
         self.addr = lob.Address.list(limit=1).data[0]
 
     def test_list_letters(self):

--- a/tests/test_postcard.py
+++ b/tests/test_postcard.py
@@ -1,10 +1,11 @@
 import unittest
+import os
 import lob
 
 
 class PostcardFunctions(unittest.TestCase):
     def setUp(self):
-        lob.api_key = 'test_fc26575412e92e22a926bc96c857f375f8b'
+        lob.api_key = os.environ.get('LOB_API_KEY')
         self.addr = lob.Address.list(limit=1).data[0]
 
     def test_list_postcards(self):

--- a/tests/test_us_autocompletion.py
+++ b/tests/test_us_autocompletion.py
@@ -1,10 +1,11 @@
 import unittest
+import os
 import lob
 
 
 class TestUSAutocompletionFunctions(unittest.TestCase):
     def setUp(self):
-        lob.api_key = 'test_fc26575412e92e22a926bc96c857f375f8b'
+        lob.api_key = os.environ.get('LOB_API_KEY')
 
     def test_us_autocompletion(self):
         autocompletion = lob.USAutocompletion.create(

--- a/tests/test_us_verification.py
+++ b/tests/test_us_verification.py
@@ -1,10 +1,11 @@
 import unittest
+import os
 import lob
 
 
 class TestUSVerificationFunctions(unittest.TestCase):
     def setUp(self):
-        lob.api_key = 'test_fc26575412e92e22a926bc96c857f375f8b'
+        lob.api_key = os.environ.get('LOB_API_KEY')
 
     def test_us_verification(self):
         addr = lob.USVerification.create(

--- a/tests/test_us_zip_lookup.py
+++ b/tests/test_us_zip_lookup.py
@@ -1,10 +1,11 @@
 import unittest
+import os
 import lob
 
 
 class TestUSZipLookupFunctions(unittest.TestCase):
     def setUp(self):
-        lob.api_key = 'test_fc26575412e92e22a926bc96c857f375f8b'
+        lob.api_key = os.environ.get('LOB_API_KEY')
 
     def test_us_zip_lookup(self):
         zip_lookup = lob.USZipLookup.create(


### PR DESCRIPTION
## What
* Removes all lob api keys from source code
* Updates testing instructions in README

## Why
No need to expose API keys