### PR TITLE
fix(examples): make examples python3 and make metadata work

### DIFF
--- a/examples/check.py
+++ b/examples/check.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import sys
 import os
 

--- a/examples/check.py
+++ b/examples/check.py
@@ -1,7 +1,9 @@
 import sys
 import os
-import lob
+
+# Load lob-python root directory into the import path so you can use the lob package without having to install it through pip.
 sys.path.insert(0, os.path.abspath(__file__+'../../..'))
+import lob
 
 # Replace this API key with your own.
 lob.api_key = 'YOUR_API_KEY'
@@ -21,15 +23,15 @@ example_address = lob.Address.create(
     address_zip='12345'
 )
 
-print "\n"
-print "Address Response"
-print "\n"
-print "======================================================="
-print "\n"
-print example_address
-print "\n"
-print "======================================================="
-print "\n"
+print("\n")
+print("Address Response")
+print("\n")
+print("=======================================================")
+print("\n")
+print(example_address)
+print("\n")
+print("=======================================================")
+print("\n")
 
 # Creating a Bank Account using the previously created account_address
 
@@ -41,14 +43,14 @@ example_bank_account = lob.BankAccount.create(
     signatory='John Doe'
 )
 
-print "Bank Account Response"
-print "\n"
-print "======================================================="
-print "\n"
-print example_bank_account
-print "\n"
-print "======================================================="
-print "\n"
+print("Bank Account Response")
+print("\n")
+print("=======================================================")
+print("\n")
+print(example_bank_account)
+print("\n")
+print("=======================================================")
+print("\n")
 
 # Verifying a Bank Account with the microdeposit amounts
 
@@ -57,14 +59,14 @@ example_bank_account = lob.BankAccount.verify(
     amounts=[23, 77]
 )
 
-print "Bank Account Verify Response"
-print "\n"
-print "======================================================="
-print "\n"
-print example_bank_account
-print "\n"
-print "======================================================="
-print "\n"
+print("Bank Account Verify Response")
+print("\n")
+print("=======================================================")
+print("\n")
+print(example_bank_account)
+print("\n")
+print("=======================================================")
+print("\n")
 
 # Creating a Check using the previously created and verified bank account
 
@@ -104,11 +106,11 @@ example_check = lob.Check.create(
     logo='https://s3-us-west-2.amazonaws.com/public.lob.com/assets/check_logo.png'
 )
 
-print "Check Response"
-print "\n"
-print "======================================================="
-print "\n"
-print example_check
-print "\n"
-print "======================================================="
-print "\n"
+print("Check Response")
+print("\n")
+print("=======================================================")
+print("\n")
+print(example_check)
+print("\n")
+print("=======================================================")
+print("\n")

--- a/examples/create_checks_from_csv/check.py
+++ b/examples/create_checks_from_csv/check.py
@@ -4,11 +4,12 @@
 
 import csv
 import datetime
-import lob
 import os
 import sys
 
+# Load lob-python root directory into the import path so you can use the lob package without having to install it through pip.
 sys.path.insert(0, os.path.abspath(__file__+'../../..'))
+import lob
 
 ###########################################################
 # TODO: Provide your API Key, keep this secure

--- a/examples/create_checks_from_csv/check.py
+++ b/examples/create_checks_from_csv/check.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 # usage:
 #   python check.py input.csv
 #   logs to csv's in the output directory

--- a/examples/create_letters_from_csv/letters.py
+++ b/examples/create_letters_from_csv/letters.py
@@ -4,11 +4,12 @@
 
 import csv
 import datetime
-import lob
 import os
 import sys
 
+# Load lob-python root directory into the import path so you can use the lob package without having to install it through pip.
 sys.path.insert(0, os.path.abspath(__file__+'../../..'))
+import lob
 
 ###########################################################
 # TODO: Provide your API Key, keep this secure

--- a/examples/create_letters_from_csv/letters.py
+++ b/examples/create_letters_from_csv/letters.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 # usage:
 #   python letters.py input.csv
 #   logs to csv's in the output directory

--- a/examples/create_letters_from_csv_async/letters.py
+++ b/examples/create_letters_from_csv_async/letters.py
@@ -19,10 +19,11 @@ import csv
 import datetime
 import os
 
+# Load lob-python root directory into the import path so you can use the lob package without having to install it through pip.
+sys.path.insert(0, os.path.abspath(__file__+'../../..'))
 import lob
 
 MAX_CONCURRENCY = 5
-sys.path.insert(0, os.path.abspath(__file__+'../../..'))
 
 ###########################################################
 # TODO: Provide your API Key, keep this secure

--- a/examples/create_postcards_from_csv/postcards.py
+++ b/examples/create_postcards_from_csv/postcards.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 # usage:
 #   python postcard.py input.csv
 #   logs to csv's in the output directory

--- a/examples/create_postcards_from_csv/postcards.py
+++ b/examples/create_postcards_from_csv/postcards.py
@@ -4,11 +4,12 @@
 
 import csv
 import datetime
-import lob
 import os
 import sys
 
+# Load lob-python root directory into the import path so you can use the lob package without having to install it through pip.
 sys.path.insert(0, os.path.abspath(__file__+'../../..'))
+import lob
 
 ###########################################################
 # TODO: Provide your API Key, keep this secure

--- a/examples/letter.py
+++ b/examples/letter.py
@@ -1,7 +1,9 @@
 import sys
 import os
-import lob
+
+# Load lob-python root directory into the import path so you can use the lob package without having to install it through pip.
 sys.path.insert(0, os.path.abspath(__file__+'../../..'))
+import lob
 
 # Replace this API key with your own.
 lob.api_key = 'YOUR_API_KEY'
@@ -21,15 +23,15 @@ example_address = lob.Address.create(
     address_zip='12345'
 )
 
-print "\n"
-print "Address Response"
-print "\n"
-print "======================================================="
-print "\n"
-print example_address
-print "\n"
-print "======================================================="
-print "\n"
+print("\n")
+print("Address Response")
+print("\n")
+print("=======================================================")
+print("\n")
+print(example_address)
+print("\n")
+print("=======================================================")
+print("\n")
 
 # Creating a Letter
 
@@ -67,11 +69,11 @@ example_letter = lob.Letter.create(
     color=True
 )
 
-print "Letter Response"
-print "\n"
-print "======================================================="
-print "\n"
-print example_letter
-print "\n"
-print "======================================================="
-print "\n"
+print("Letter Response")
+print("\n")
+print("=======================================================")
+print("\n")
+print(example_letter)
+print("\n")
+print("=======================================================")
+print("\n")

--- a/examples/letter.py
+++ b/examples/letter.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import sys
 import os
 

--- a/examples/postcard.py
+++ b/examples/postcard.py
@@ -1,7 +1,9 @@
 import sys
 import os
-import lob
+
+# Load lob-python root directory into the import path so you can use the lob package without having to install it through pip.
 sys.path.insert(0, os.path.abspath(__file__+'../../..'))
+import lob
 
 # Replace this API key with your own.
 lob.api_key = 'YOUR_API_KEY'
@@ -21,15 +23,15 @@ example_address = lob.Address.create(
     address_zip='12345'
 )
 
-print "\n"
-print "Address Response"
-print "\n"
-print "======================================================="
-print "\n"
-print example_address
-print "\n"
-print "======================================================="
-print "\n"
+print("\n")
+print("Address Response")
+print("\n")
+print("=======================================================")
+print("\n")
+print(example_address)
+print("\n")
+print("=======================================================")
+print("\n")
 
 # Creating a Postcard
 
@@ -58,11 +60,11 @@ example_postcard = lob.Postcard.create(
     back="<h1>Welcome to the club!</h1>"
 )
 
-print "Postcard Response"
-print "\n"
-print "======================================================="
-print "\n"
-print example_postcard
-print "\n"
-print "======================================================="
-print "\n"
+print("Postcard Response")
+print("\n")
+print("=======================================================")
+print("\n")
+print(example_postcard)
+print("\n")
+print("=======================================================")
+print("\n")

--- a/examples/postcard.py
+++ b/examples/postcard.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import sys
 import os
 

--- a/examples/verify_addresses_from_csv/verify.py
+++ b/examples/verify_addresses_from_csv/verify.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 # usage:
 #     python verify.py input.csv
 #     logs output in csv directory

--- a/examples/verify_addresses_from_csv/verify.py
+++ b/examples/verify_addresses_from_csv/verify.py
@@ -4,11 +4,12 @@
 
 import csv
 import datetime
-import lob
 import os
 import sys
 
+# Load lob-python root directory into the import path so you can use the lob package without having to install it through pip.
 sys.path.insert(0, os.path.abspath(__file__+'../../../..'))
+import lob
 
 # TODO: Provide your API key, keep this secure
 lob.api_key = 'YOUR_API_KEY'

--- a/lob/api_requestor.py
+++ b/lob/api_requestor.py
@@ -85,7 +85,11 @@ class APIRequestor(object):
                     if isinstance(v, lob.resource.LobObject):
                         data[k] = v.id
                     else:
-                        data[k] = v
+                        if isinstance(v, dict):
+                            for k2, v2 in v.items():
+                                data[k + '[' + k2 + ']'] = v2
+                        else:
+                            data[k] = v
 
             return self.parse_response(
                 requests.post(lob.api_base + url, auth=(self.api_key, ''), params=query, data=data, files=files, headers=headers)

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -53,7 +53,10 @@ class CheckFunctions(unittest.TestCase):
                 'address_line2': 'Suite 1510',
                 'address_city': 'San Francisco',
                 'address_zip': '94107',
-                'address_state': 'CA'
+                'address_state': 'CA',
+                'metadata': {
+                    'department': 'marketing'
+                }
             },
             from_address={
                 'name': 'Lob',

--- a/tests/test_letter.py
+++ b/tests/test_letter.py
@@ -24,7 +24,10 @@ class LetterFunctions(unittest.TestCase):
                 'address_line1': '1859 Kinney St',
                 'address_city': 'Agawam',
                 'address_zip': '01001',
-                'address_state': 'MA'
+                'address_state': 'MA',
+                'metadata': {
+                    'department': 'marketing'
+                }
             },
             to_address=self.addr.id,
             file='<h1>{{name}}</h1>',

--- a/tests/test_postcard.py
+++ b/tests/test_postcard.py
@@ -87,7 +87,10 @@ class PostcardFunctions(unittest.TestCase):
                 'address_line2': 'Suite 1510',
                 'address_city': 'San Francisco',
                 'address_zip': '94107',
-                'address_state': 'CA'
+                'address_state': 'CA',
+                'metadata': {
+                    'department': 'marketing'
+                }
             },
             from_address={
                 'name': 'Lob2',


### PR DESCRIPTION
## What
* Makes our p/l/c examples python3-compatible
* Adds back logic to support nested objects (e.g. payload['to']['metadata']['department'])

## Why
* Python 2 is on its way out, so our examples should be python3-compatible
* The python library should be able to support nested objects for things like `metadata`.