### PR TITLE
chore(release): Improve release & version hygiene

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,8 @@
+[bumpversion]
+current_version = 4.0.0
+commit = True
+tag = True
+
+[bumpversion:file:setup.py]
+
+[bumpversion:file:lob/version.py]

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
 - '3.6'
 - '3.7'
 - 'pypy'
+- 'pypy3.5'
 before_install:
   - pip install "pip==18.0.0"
   - pip install pipenv

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ dist: xenial
 language: python
 python:
 - '2.7'
-- '3.4'
 - '3.5'
 - '3.6'
 - '3.7'

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,12 @@ python:
 - '3.5'
 - '3.6'
 - 'pypy'
+before_install:
+  - pip install pipenv
 install:
-  - pip install -r requirements.txt
+  - pipenv install --dev
 script:
-  - nosetests  --with-coverage --cover-package=lob
+  - pipenv run nosetests  --with-coverage --cover-package=lob
 after_success:
   - coveralls
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,14 @@
+dist: xenial
 language: python
 python:
 - '2.7'
 - '3.4'
 - '3.5'
 - '3.6'
+- '3.7'
 - 'pypy'
 before_install:
+  - pip install "pip==18.0.0"
   - pip install pipenv
 install:
   - pipenv install --dev

--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,15 @@
+[[source]]
+url = "https://pypi.python.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+requests = "*"
+
+[dev-packages]
+nose = "*"
+"flake8" = "*"
+coverage = "*"
+coveralls = "*"
+
+[requires]

--- a/Pipfile
+++ b/Pipfile
@@ -12,5 +12,7 @@ nose = "*"
 coverage = "*"
 coveralls = "*"
 bumpversion = "*"
+setuptools = "*"
+twine = "*"
 
 [requires]

--- a/Pipfile
+++ b/Pipfile
@@ -11,5 +11,6 @@ nose = "*"
 "flake8" = "*"
 coverage = "*"
 coveralls = "*"
+bumpversion = "*"
 
 [requires]

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "3498c42a26a13cd8e85ed36c6a4e8d2dd9149e16904a65acc26444b7d4eab754"
+            "sha256": "31d2be7d564f5c79b37b24ce4be7635cabd8d833b9d80c0ab2e13607143d7868"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -52,6 +52,13 @@
         }
     },
     "develop": {
+        "bleach": {
+            "hashes": [
+                "sha256:213336e49e102af26d9cde77dd2d0397afabc5a6bf2fed985dc35b5d1e285a16",
+                "sha256:3fdf7f77adcf649c9911387df51254b813185e32b2c6619f690b593a617e19fa"
+            ],
+            "version": "==3.1.0"
+        },
         "bumpversion": {
             "hashes": [
                 "sha256:6744c873dd7aafc24453d8b6a1a0d6d109faf63cd0cd19cb78fd46e74932c77e",
@@ -125,6 +132,14 @@
             ],
             "version": "==0.6.2"
         },
+        "docutils": {
+            "hashes": [
+                "sha256:02aec4bd92ab067f6ff27a38a38a41173bf01bed8f89157768c1573f53e474a6",
+                "sha256:51e64ef2ebfb29cae1faa133b3710143496eca21c530f3f71424d77687764274",
+                "sha256:7a4bd47eaf6596e1295ecb11361139febe29b084a87bf005bf899f9a42edc3c6"
+            ],
+            "version": "==0.14"
+        },
         "entrypoints": {
             "hashes": [
                 "sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19",
@@ -163,6 +178,13 @@
             "index": "pypi",
             "version": "==1.3.7"
         },
+        "pkginfo": {
+            "hashes": [
+                "sha256:7424f2c8511c186cd5424bbf31045b77435b37a8d604990b79d4e70d741148bb",
+                "sha256:a6d9e40ca61ad3ebd0b72fbadd4fba16e4c0e4df0428c041e01e06eb6ee71f32"
+            ],
+            "version": "==1.5.0.1"
+        },
         "pycodestyle": {
             "hashes": [
                 "sha256:95a2219d12372f05704562a14ec30bc76b05a5b297b21a5dfe3f6fac3491ae56",
@@ -177,6 +199,20 @@
             ],
             "version": "==2.1.1"
         },
+        "pygments": {
+            "hashes": [
+                "sha256:31cba6ffb739f099a85e243eff8cb717089fdd3c7300767d9fc34cb8e1b065f5",
+                "sha256:5ad302949b3c98dd73f8d9fcdc7e9cb592f120e32a18e23efd7f3dc51194472b"
+            ],
+            "version": "==2.4.0"
+        },
+        "readme-renderer": {
+            "hashes": [
+                "sha256:bb16f55b259f27f75f640acf5e00cf897845a8b3e4731b5c1a436e4b8529202f",
+                "sha256:c8532b79afc0375a85f10433eca157d6b50f7d6990f337fa498c96cd4bfc203d"
+            ],
+            "version": "==24.0"
+        },
         "requests": {
             "hashes": [
                 "sha256:502a824f31acdacb3a35b6690b5fbf0bc41d63a24a45c4004352b0242707598e",
@@ -185,12 +221,48 @@
             "index": "pypi",
             "version": "==2.21.0"
         },
+        "requests-toolbelt": {
+            "hashes": [
+                "sha256:380606e1d10dc85c3bd47bf5a6095f815ec007be7a8b69c878507068df059e6f",
+                "sha256:968089d4584ad4ad7c171454f0a5c6dac23971e9472521ea3b6d49d610aa6fc0"
+            ],
+            "version": "==0.9.1"
+        },
+        "six": {
+            "hashes": [
+                "sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c",
+                "sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
+            ],
+            "version": "==1.12.0"
+        },
+        "tqdm": {
+            "hashes": [
+                "sha256:0a860bf2683fdbb4812fe539a6c22ea3f1777843ea985cb8c3807db448a0f7ab",
+                "sha256:e288416eecd4df19d12407d0c913cbf77aa8009d7fddb18f632aded3bdbdda6b"
+            ],
+            "version": "==4.32.1"
+        },
+        "twine": {
+            "hashes": [
+                "sha256:0fb0bfa3df4f62076cab5def36b1a71a2e4acb4d1fa5c97475b048117b1a6446",
+                "sha256:d6c29c933ecfc74e9b1d9fa13aa1f87c5d5770e119f5a4ce032092f0ff5b14dc"
+            ],
+            "index": "pypi",
+            "version": "==1.13.0"
+        },
         "urllib3": {
             "hashes": [
                 "sha256:2393a695cd12afedd0dcb26fe5d50d0cf248e5a66f75dbd89a3d4eb333a61af4",
                 "sha256:a637e5fae88995b256e3409dc4d52c2e2e0ba32c42a6365fee8bbd2238de3cfb"
             ],
             "version": "==1.24.3"
+        },
+        "webencodings": {
+            "hashes": [
+                "sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78",
+                "sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923"
+            ],
+            "version": "==0.5.1"
         }
     }
 }

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "c7f4641c338d57f60046f425a75f1d99d707baeb767f4217c5e8a10251c434b6"
+            "sha256": "3498c42a26a13cd8e85ed36c6a4e8d2dd9149e16904a65acc26444b7d4eab754"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -52,6 +52,14 @@
         }
     },
     "develop": {
+        "bumpversion": {
+            "hashes": [
+                "sha256:6744c873dd7aafc24453d8b6a1a0d6d109faf63cd0cd19cb78fd46e74932c77e",
+                "sha256:6753d9ff3552013e2130f7bc03c1007e24473b4835952679653fb132367bdd57"
+            ],
+            "index": "pypi",
+            "version": "==0.5.3"
+        },
         "certifi": {
             "hashes": [
                 "sha256:59b7658e26ca9c7339e00f8f4636cdfe59d34fa37b9b04f6f9e9926b3cece1a5",

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,0 +1,188 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "c7f4641c338d57f60046f425a75f1d99d707baeb767f4217c5e8a10251c434b6"
+        },
+        "pipfile-spec": 6,
+        "requires": {},
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.python.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "certifi": {
+            "hashes": [
+                "sha256:59b7658e26ca9c7339e00f8f4636cdfe59d34fa37b9b04f6f9e9926b3cece1a5",
+                "sha256:b26104d6835d1f5e49452a26eb2ff87fe7090b89dfcaee5ea2212697e1e1d7ae"
+            ],
+            "version": "==2019.3.9"
+        },
+        "chardet": {
+            "hashes": [
+                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae",
+                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
+            ],
+            "version": "==3.0.4"
+        },
+        "idna": {
+            "hashes": [
+                "sha256:c357b3f628cf53ae2c4c05627ecc484553142ca23264e593d327bcde5e9c3407",
+                "sha256:ea8b7f6188e6fa117537c3df7da9fc686d485087abf6ac197f9c46432f7e4a3c"
+            ],
+            "version": "==2.8"
+        },
+        "requests": {
+            "hashes": [
+                "sha256:502a824f31acdacb3a35b6690b5fbf0bc41d63a24a45c4004352b0242707598e",
+                "sha256:7bf2a778576d825600030a110f3c0e3e8edc51dfaafe1c146e39a2027784957b"
+            ],
+            "index": "pypi",
+            "version": "==2.21.0"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:2393a695cd12afedd0dcb26fe5d50d0cf248e5a66f75dbd89a3d4eb333a61af4",
+                "sha256:a637e5fae88995b256e3409dc4d52c2e2e0ba32c42a6365fee8bbd2238de3cfb"
+            ],
+            "version": "==1.24.3"
+        }
+    },
+    "develop": {
+        "certifi": {
+            "hashes": [
+                "sha256:59b7658e26ca9c7339e00f8f4636cdfe59d34fa37b9b04f6f9e9926b3cece1a5",
+                "sha256:b26104d6835d1f5e49452a26eb2ff87fe7090b89dfcaee5ea2212697e1e1d7ae"
+            ],
+            "version": "==2019.3.9"
+        },
+        "chardet": {
+            "hashes": [
+                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae",
+                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
+            ],
+            "version": "==3.0.4"
+        },
+        "coverage": {
+            "hashes": [
+                "sha256:3684fabf6b87a369017756b551cef29e505cb155ddb892a7a29277b978da88b9",
+                "sha256:39e088da9b284f1bd17c750ac672103779f7954ce6125fd4382134ac8d152d74",
+                "sha256:3c205bc11cc4fcc57b761c2da73b9b72a59f8d5ca89979afb0c1c6f9e53c7390",
+                "sha256:465ce53a8c0f3a7950dfb836438442f833cf6663d407f37d8c52fe7b6e56d7e8",
+                "sha256:48020e343fc40f72a442c8a1334284620f81295256a6b6ca6d8aa1350c763bbe",
+                "sha256:5296fc86ab612ec12394565c500b412a43b328b3907c0d14358950d06fd83baf",
+                "sha256:5f61bed2f7d9b6a9ab935150a6b23d7f84b8055524e7be7715b6513f3328138e",
+                "sha256:68a43a9f9f83693ce0414d17e019daee7ab3f7113a70c79a3dd4c2f704e4d741",
+                "sha256:6b8033d47fe22506856fe450470ccb1d8ba1ffb8463494a15cfc96392a288c09",
+                "sha256:7ad7536066b28863e5835e8cfeaa794b7fe352d99a8cded9f43d1161be8e9fbd",
+                "sha256:7bacb89ccf4bedb30b277e96e4cc68cd1369ca6841bde7b005191b54d3dd1034",
+                "sha256:839dc7c36501254e14331bcb98b27002aa415e4af7ea039d9009409b9d2d5420",
+                "sha256:8f9a95b66969cdea53ec992ecea5406c5bd99c9221f539bca1e8406b200ae98c",
+                "sha256:932c03d2d565f75961ba1d3cec41ddde00e162c5b46d03f7423edcb807734eab",
+                "sha256:988529edadc49039d205e0aa6ce049c5ccda4acb2d6c3c5c550c17e8c02c05ba",
+                "sha256:998d7e73548fe395eeb294495a04d38942edb66d1fa61eb70418871bc621227e",
+                "sha256:9de60893fb447d1e797f6bf08fdf0dbcda0c1e34c1b06c92bd3a363c0ea8c609",
+                "sha256:9e80d45d0c7fcee54e22771db7f1b0b126fb4a6c0a2e5afa72f66827207ff2f2",
+                "sha256:a545a3dfe5082dc8e8c3eb7f8a2cf4f2870902ff1860bd99b6198cfd1f9d1f49",
+                "sha256:a5d8f29e5ec661143621a8f4de51adfb300d7a476224156a39a392254f70687b",
+                "sha256:aca06bfba4759bbdb09bf52ebb15ae20268ee1f6747417837926fae990ebc41d",
+                "sha256:bb23b7a6fd666e551a3094ab896a57809e010059540ad20acbeec03a154224ce",
+                "sha256:bfd1d0ae7e292105f29d7deaa9d8f2916ed8553ab9d5f39ec65bcf5deadff3f9",
+                "sha256:c62ca0a38958f541a73cf86acdab020c2091631c137bd359c4f5bddde7b75fd4",
+                "sha256:c709d8bda72cf4cd348ccec2a4881f2c5848fd72903c185f363d361b2737f773",
+                "sha256:c968a6aa7e0b56ecbd28531ddf439c2ec103610d3e2bf3b75b813304f8cb7723",
+                "sha256:df785d8cb80539d0b55fd47183264b7002077859028dfe3070cf6359bf8b2d9c",
+                "sha256:f406628ca51e0ae90ae76ea8398677a921b36f0bd71aab2099dfed08abd0322f",
+                "sha256:f46087bbd95ebae244a0eda01a618aff11ec7a069b15a3ef8f6b520db523dcf1",
+                "sha256:f8019c5279eb32360ca03e9fac40a12667715546eed5c5eb59eb381f2f501260",
+                "sha256:fc5f4d209733750afd2714e9109816a29500718b32dd9a5db01c0cb3a019b96a"
+            ],
+            "index": "pypi",
+            "version": "==4.5.3"
+        },
+        "coveralls": {
+            "hashes": [
+                "sha256:baa26648430d5c2225ab12d7e2067f75597a4b967034bba7e3d5ab7501d207a1",
+                "sha256:ff9b7823b15070f26f654837bb02a201d006baaf2083e0514ffd3b34a3ffed81"
+            ],
+            "index": "pypi",
+            "version": "==1.7.0"
+        },
+        "docopt": {
+            "hashes": [
+                "sha256:49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491"
+            ],
+            "version": "==0.6.2"
+        },
+        "entrypoints": {
+            "hashes": [
+                "sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19",
+                "sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451"
+            ],
+            "version": "==0.3"
+        },
+        "flake8": {
+            "hashes": [
+                "sha256:859996073f341f2670741b51ec1e67a01da142831aa1fdc6242dbf88dffbe661",
+                "sha256:a796a115208f5c03b18f332f7c11729812c8c3ded6c46319c59b53efd3819da8"
+            ],
+            "index": "pypi",
+            "version": "==3.7.7"
+        },
+        "idna": {
+            "hashes": [
+                "sha256:c357b3f628cf53ae2c4c05627ecc484553142ca23264e593d327bcde5e9c3407",
+                "sha256:ea8b7f6188e6fa117537c3df7da9fc686d485087abf6ac197f9c46432f7e4a3c"
+            ],
+            "version": "==2.8"
+        },
+        "mccabe": {
+            "hashes": [
+                "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42",
+                "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"
+            ],
+            "version": "==0.6.1"
+        },
+        "nose": {
+            "hashes": [
+                "sha256:9ff7c6cc443f8c51994b34a667bbcf45afd6d945be7477b52e97516fd17c53ac",
+                "sha256:dadcddc0aefbf99eea214e0f1232b94f2fa9bd98fa8353711dacb112bfcbbb2a",
+                "sha256:f1bffef9cbc82628f6e7d7b40d7e255aefaa1adb6a1b1d26c69a8b79e6208a98"
+            ],
+            "index": "pypi",
+            "version": "==1.3.7"
+        },
+        "pycodestyle": {
+            "hashes": [
+                "sha256:95a2219d12372f05704562a14ec30bc76b05a5b297b21a5dfe3f6fac3491ae56",
+                "sha256:e40a936c9a450ad81df37f549d676d127b1b66000a6c500caa2b085bc0ca976c"
+            ],
+            "version": "==2.5.0"
+        },
+        "pyflakes": {
+            "hashes": [
+                "sha256:17dbeb2e3f4d772725c777fabc446d5634d1038f234e77343108ce445ea69ce0",
+                "sha256:d976835886f8c5b31d47970ed689944a0262b5f3afa00a5a7b4dc81e5449f8a2"
+            ],
+            "version": "==2.1.1"
+        },
+        "requests": {
+            "hashes": [
+                "sha256:502a824f31acdacb3a35b6690b5fbf0bc41d63a24a45c4004352b0242707598e",
+                "sha256:7bf2a778576d825600030a110f3c0e3e8edc51dfaafe1c146e39a2027784957b"
+            ],
+            "index": "pypi",
+            "version": "==2.21.0"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:2393a695cd12afedd0dcb26fe5d50d0cf248e5a66f75dbd89a3d4eb333a61af4",
+                "sha256:a637e5fae88995b256e3409dc4d52c2e2e0ba32c42a6365fee8bbd2238de3cfb"
+            ],
+            "version": "==1.24.3"
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -6,7 +6,15 @@
 
 This is the python wrapper for the Lob.com API. See full Lob.com documentation [here](https://lob.com/docs/python). For best results, be sure that you're using [the latest version](https://lob.com/docs/python#version) of the Lob API and the latest version of the python wrapper.
 
-This wrapper supports Python 2.7, 3.4, 3.5, 3.6, 3.7, pypy, and pypy3 and works in the object oriented style. That is, to make calls you have to call the method on a class and the return types are python objects. To get a `dict` on any object, you can call the `to_dict()` method of the object.
+This library supports active Python releases (i.e., versions which have not reached their end of life), as well as PyPy and PyPy 3.
+The currently supported versions include:
+
+* Python 2.7
+* Python 3.5
+* Python 3.6
+* Python 3.7
+* PyPy
+* PyPy 3
 
 ## Table of Contents
 
@@ -19,6 +27,8 @@ This wrapper supports Python 2.7, 3.4, 3.5, 3.6, 3.7, pypy, and pypy3 and works 
 - [Testing](#testing)
 
 ## Getting Started
+
+Lob Python wrapper works in the object oriented style. That is, to make calls you have to call the method on a class and the return types are python objects. To get a `dict` on any object, you can call the `to_dict()` method of the object.
 
 Here's a general overview of the Lob services available, click through to read more.
 
@@ -37,11 +47,10 @@ Once you have created an account, you can access your API Keys from the [Setting
 
 ### Installation
 
-You can use `pip` or `easy_install` for installing the package.
+You can use `pip` to install the package.
 
 ```
 pip install lob
-easy_install lob
 ```
 
 To initialize the wrapper, import `lob` and set the `api_key`

--- a/README.md
+++ b/README.md
@@ -134,12 +134,23 @@ There are simple scripts to demonstrate how to create all the core Lob objects (
 
 ## Testing
 
-Install all requirements with `pip install -r requirements.txt`.
+lob-python uses [Pipenv](https://docs.pipenv.org/) to manage development environments and dependencies.
+
+You install all the development requirements by running
+
+```shell
+$ pipenv install --dev
+$ pipenv shell
+```
 
 You can run all tests with the command `LOB_API_KEY=YOUR_TEST_API_KEY nosetests` in the main directory.
 
+```shell
+$ nosetests
+```
+
 =======================
 
-Copyright &copy; 2013 Lob.com
+Copyright &copy; 2013-2018 Lob.com
 
 Released under the MIT License, which can be found in the repository in `LICENSE.txt`.

--- a/README.md
+++ b/README.md
@@ -149,7 +149,27 @@ You can run all tests with the command `LOB_API_KEY=YOUR_TEST_API_KEY nosetests`
 $ nosetests
 ```
 
-=======================
+## Making Releases
+
+lob-python includes [bumpversion](https://pypi.org/project/bumpversion/) as a development dependency. This
+tool should be used when changing the version number, as it will ensure that it's updated correctly and
+consistently.
+
+Running bumpversion will increment the specified version part (`major`, `minor`, `patch`), commit the change,
+and tag it.
+
+```shell
+$ bumpversion <part>
+```
+
+After the version has been bumped, you can push the change and tag.
+
+```shell
+$ git push origin head
+$ git push origin --tags
+```
+
+---
 
 Copyright &copy; 2013-2019 Lob.com
 

--- a/README.md
+++ b/README.md
@@ -169,6 +169,17 @@ $ git push origin head
 $ git push origin --tags
 ```
 
+Finally, create the distribution and push it to PyPI using [twine](https://pypi.org/project/twine/).
+
+```shell
+$ python setup.py sdist
+...
+Writing lob-4.0.0/setup.cfg
+Creating tar archive
+removing 'lob-4.0.0' (and everything under it)
+$ twine upload dist/lob-4.0.0.tar.gz
+```
+
 ---
 
 Copyright &copy; 2013-2019 Lob.com

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 This is the python wrapper for the Lob.com API. See full Lob.com documentation [here](https://lob.com/docs/python). For best results, be sure that you're using [the latest version](https://lob.com/docs/python#version) of the Lob API and the latest version of the python wrapper.
 
-This wrapper supports Python 2.7, 3.4, 3.5, 3.6, pypy, and pypy3 and works in the object oriented style. That is, to make calls you have to call the method on a class and the return types are python objects. To get a `dict` on any object, you can call the `to_dict()` method of the object.
+This wrapper supports Python 2.7, 3.4, 3.5, 3.6, 3.7, pypy, and pypy3 and works in the object oriented style. That is, to make calls you have to call the method on a class and the return types are python objects. To get a `dict` on any object, you can call the `to_dict()` method of the object.
 
 ## Table of Contents
 
@@ -151,6 +151,6 @@ $ nosetests
 
 =======================
 
-Copyright &copy; 2013-2018 Lob.com
+Copyright &copy; 2013-2019 Lob.com
 
 Released under the MIT License, which can be found in the repository in `LICENSE.txt`.

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ $ pipenv shell
 You can run all tests with the command `LOB_API_KEY=YOUR_TEST_API_KEY nosetests` in the main directory.
 
 ```shell
-$ nosetests
+$ LOB_API_KEY=YOUR_TEST_API_KEY nosetests
 ```
 
 ## Making Releases

--- a/lob/version.py
+++ b/lob/version.py
@@ -1,3 +1,3 @@
 from __future__ import unicode_literals
 
-VERSION = '3.4.0'
+VERSION = '4.0.0'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,0 @@
-nose
-flake8
-requests
-coverage
-coveralls

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,6 @@ setup(
         "Programming Language :: Python",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",

--- a/setup.py
+++ b/setup.py
@@ -19,12 +19,12 @@ setup(
         "Development Status :: 5 - Production/Stable",
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 2.6",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.3",
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy"
     ]

--- a/setup.py
+++ b/setup.py
@@ -5,12 +5,12 @@ except ImportError:
 
 setup(
     name='lob',
-    version='3.4.0',
+    version='4.0.0',
     author='Lob',
     author_email='support@lob.com',
     packages=['lob'],
     description='Lob Python Bindings',
-    url='https://www.lob.com',
+    url='https://github.com/lob/lob-python',
     license='MIT',
     install_requires=[
         'requests'

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
-try:
-    from setuptools import setup
-except ImportError:
-    from disutils.core import setup
+from setuptools import setup
+
+README = open('README.md').read()
 
 setup(
     name='lob',
@@ -10,11 +9,13 @@ setup(
     author_email='support@lob.com',
     packages=['lob'],
     description='Lob Python Bindings',
+    long_description=README,
+    long_description_content_type="text/markdown",
     url='https://github.com/lob/lob-python',
     license='MIT',
     install_requires=[
         'requests'
-        ],
+    ],
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "License :: OSI Approved :: MIT License",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py34,py35,py36,py37,pypy,pypy3
+envlist = py27,py35,py36,py37,pypy,pypy3
 
 [testenv]
 usedevelop = True


### PR DESCRIPTION
This PR contains a few chore commits to improve the way we manage our dependencies and make releases.

* Updates to use pipenv, which is now the recommended way to manage virtualenvs
* Updates CI & metadata versions to support Python 3.7
* Adds bumpversion, a utility for, ahem, bumping the version consistently
* Populates the project description on https://pypi.org/project/lob/ (which is currently, sadly, empty)