### PR TITLE
chore(template-syntax): allow nested merge variables

### DIFF
--- a/lob/api_requestor.py
+++ b/lob/api_requestor.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 
 import requests
+import json
 
 import lob
 from lob import error
@@ -72,7 +73,9 @@ class APIRequestor(object):
                 del params['query']
 
             for k, v in params.items():
-                if isinstance(v, dict) and not isinstance(v, lob.resource.LobObject):
+                if k == 'merge_variables':
+                    explodedParams[k] = json.dumps(v)
+                elif isinstance(v, dict) and not isinstance(v, lob.resource.LobObject):
                     for k2, v2 in v.items():
                         explodedParams[k + '[' + k2 + ']'] = v2
                 else:

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -75,6 +75,26 @@ class CheckFunctions(unittest.TestCase):
         self.assertEqual(check.to_address.name, 'LOB')
         self.assertEqual(check.from_address.name, 'LOB')
 
+    def test_create_check_with_merge_variable_conditional(self):
+        check = lob.Check.create(
+            description='Test Check',
+            bank_account=self.ba.id,
+            to_address=self.addr.id,
+            from_address=self.addr.id,
+            amount=1000,
+            memo='Test Check',
+            attachment="<html>{{#is_awesome}}You are awesome!{{/is_awesome}}</html>",
+            check_bottom="<html>{{#is_awesome}}You are awesome!{{/is_awesome}}</html>",
+            merge_variables={
+                'is_awesome': True
+            }
+        )
+
+        self.assertTrue(isinstance(check, lob.Check))
+        self.assertEqual(check.bank_account.id, self.ba.id)
+        self.assertEqual(check.to_address.id, self.addr.id)
+        self.assertEqual(check.from_address.id, self.addr.id)
+
     def test_delete_postcard(self):
         check = lob.Check.create(
             description='Test Check',

--- a/tests/test_letter.py
+++ b/tests/test_letter.py
@@ -39,6 +39,30 @@ class LetterFunctions(unittest.TestCase):
         self.assertEqual(letter.to_address.id, self.addr.id)
         self.assertTrue(isinstance(letter, lob.Letter))
 
+    def test_create_letter_with_merge_variable_object(self):
+        letter = lob.Letter.create(
+            from_address={
+                'name': 'Keanu Reeves',
+                'address_line1': '1234 Fake St',
+                'address_city': 'Zion',
+                'address_zip': '12345',
+                'address_state': 'CA',
+                'metadata': {
+                    'matrix': 'is_real'
+                }
+            },
+            to_address=self.addr.id,
+            file='<html>{{data.name}}</html>',
+            merge_variables={
+                'data': {
+                    'name': 'Delbert'
+                }
+            },
+            color=True
+        )
+        self.assertEqual(letter.to_address.id, self.addr.id)
+        self.assertTrue(isinstance(letter, lob.Letter))
+
     def test_delete_letter(self):
         letter = lob.Letter.create(
             from_address={

--- a/tests/test_postcard.py
+++ b/tests/test_postcard.py
@@ -120,6 +120,23 @@ class PostcardFunctions(unittest.TestCase):
         )
         self.assertTrue(isinstance(postcard, lob.Postcard))
 
+    def test_create_postcard_with_merge_variable_list(self):
+        postcard = lob.Postcard.create(
+            to_address=self.addr.id,
+            from_address=self.addr.id,
+            front='<html>{{#list}} {{name}} {{/list}}</html>',
+            back='<html>{{#list}} {{name}} {{/list}}</html>',
+            merge_variables={
+                'list': [
+                    { 'name': 'Larissa' },
+                    { 'name': 'Larry' }
+                ]
+            }
+        )
+        self.assertEqual(postcard.to_address.id, self.addr.id)
+        self.assertEqual(postcard.from_address.id, self.addr.id)
+        self.assertTrue(isinstance(postcard, lob.Postcard))
+
     def test_delete_postcard(self):
         postcard = lob.Postcard.create(
             to_address=self.addr.id,

--- a/tests/test_us_verification.py
+++ b/tests/test_us_verification.py
@@ -24,7 +24,7 @@ class TestUSVerificationFunctions(unittest.TestCase):
             city='San Francisco',
             state='CA',
             zip_code='94107',
-            lob_version='2018-03-30'
+            lob_version='2020-02-11'
         )
 
         self.assertEqual(addr.deliverability, 'deliverable')


### PR DESCRIPTION
## What

* Updates `api_requestor` to allow nested structs and lists for `merge_variables`
* Adds some basic tests for the new template syntax (conditionals, loops, objects)

## Why

This allows the client to send nested merge variables to go along with the advanced templating syntax feature