### PR TITLE
chore: bump version 4.0.2 -> 4.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,13 @@ There are simple scripts to demonstrate how to create all the core Lob objects (
     - [Retrieve a Postcard](https://lob.com/docs/python#postcards_retrieve)
     - [Cancel a Postcard](https://lob.com/docs/python#postcards_delete)
     - [List all Postcards](https://lob.com/docs/python#postcards_list)
+- **Self Mailers API**
+  - [Self Mailers](https://lob.com/docs/python#self_mailers)
+    - [The Self Mailer Object](https://lob.com/docs/python#self_mailers_object)
+    - [Create a Self Mailer](https://lob.com/docs/python#self_mailers_create)
+    - [Retrieve a Self Mailer](https://lob.com/docs/python#self_mailers_retrieve)
+    - [Cancel a Self Mailer](https://lob.com/docs/python#self_mailers_delete)
+    - [List all Self Mailers](https://lob.com/docs/python#self_mailers_list)
 - **Letters API**
   - [Letters](https://lob.com/docs/python#letters)
     - [The Letter Object](https://lob.com/docs/python#letters_object)
@@ -133,13 +140,6 @@ There are simple scripts to demonstrate how to create all the core Lob objects (
     - [Delete a Bank Account](https://lob.com/docs/python#bankaccounts_delete)
     - [Verify a Bank Account](https://lob.com/docs/python#bankaccounts_verify)
     - [List all Bank Accounts](https://lob.com/docs/python#bankaccounts_list)
-- **Self Mailers API**
-  - [Self Mailers](https://lob.com/docs/python#self_mailers)
-    - [The Self Mailer Object](https://lob.com/docs/python#self_mailers_object)
-    - [Create a Self Mailer](https://lob.com/docs/python#self_mailers_create)
-    - [Retrieve a Self Mailer](https://lob.com/docs/python#self_mailers_retrieve)
-    - [Cancel a Self Mailer](https://lob.com/docs/python#self_mailers_delete)
-    - [List all Self Mailers](https://lob.com/docs/python#self_mailers_list)
 - **Appendix**
   - [API Changelog](https://lob.com/docs/python#changelog)
   - [The Tracking Event Object](https://lob.com/docs/python#tracking_event_object)

--- a/lob/version.py
+++ b/lob/version.py
@@ -1,3 +1,3 @@
 from __future__ import unicode_literals
 
-VERSION = '4.0.2'
+VERSION = '4.1.0'

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ README = open('README.md').read()
 
 setup(
     name='lob',
-    version='4.0.2',
+    version='4.1.0',
     author='Lob',
     author_email='support@lob.com',
     packages=['lob'],


### PR DESCRIPTION
**What**
Updates README.md and bumps client library version identifier from 4.0.2 to 4.1.0

**Why**
Cutting new release with added self mailer support