### PR TITLE
[fix] Cards: Added Card.update route

### DIFF
--- a/examples/create_card.py
+++ b/examples/create_card.py
@@ -34,3 +34,9 @@ print(example_card)
 print("\n")
 print("=======================================================")
 print("\n")
+
+# Updating a card
+# updatedCard = lob.Card.update(example_card.id, description='This is a new description')
+
+# Deleting a card
+# deletedCard = lob.Card.delete(example_card.id)

--- a/lob/resource.py
+++ b/lob/resource.py
@@ -149,6 +149,13 @@ class BulkUSVerification(CreateableAPIResource):
 class Card(ListableAPIResource, DeleteableAPIResource, CreateableAPIResource):
     endpoint = '/cards'
 
+    @classmethod
+    def update(cls, card_id, **params):
+        requestor = api_requestor.APIRequestor()
+        response = requestor.request('post', '%s/%s' % (cls.endpoint, card_id), params)
+        return lob_format(response)
+
+
 class CardOrder(ListableAPIResource, CreateableAPIResource):
     endpoint = '/cards/%s/orders'
 

--- a/tests/test_card.py
+++ b/tests/test_card.py
@@ -20,8 +20,7 @@ class CardFunctions(unittest.TestCase):
         card = lob.Card.create(
             front=open('tests/pdfs/card.pdf', 'rb'),
             back=open('tests/pdfs/card.pdf', 'rb'),
-            description='Card with a blank PDF file',
-            size='2.125x3.375'
+            description='Card with a blank PDF file'
         )
         self.assertTrue(isinstance(card, lob.Card))
 
@@ -29,8 +28,16 @@ class CardFunctions(unittest.TestCase):
         card = lob.Card.create(
             front=open('tests/pdfs/card.pdf', 'rb'),
             back=open('tests/pdfs/card.pdf', 'rb'),
-            description='Card with a blank PDF file',
-            size='2.125x3.375'
+            description='Card with a blank PDF file'
         )
         deleted_response = lob.Card.delete(card.id)
         self.assertTrue(deleted_response.deleted)
+
+    def test_update_card(self):
+        card = lob.Card.create(
+            front=open('tests/pdfs/card.pdf', 'rb'),
+            back=open('tests/pdfs/card.pdf', 'rb'),
+            description='Card with a blank PDF file'
+        )
+        updatedCard = lob.Card.update(card.id, description='updated description')
+        self.assertEqual(updatedCard.description, 'updated description')


### PR DESCRIPTION
**What and Why**
We have an endpoint available to update a Card. We now expose that route through the SDK.