### PR TITLE
added another GH action to handle forked repos

### DIFF
--- a/.github/workflows/forked_repos.yaml
+++ b/.github/workflows/forked_repos.yaml
@@ -1,0 +1,25 @@
+name: Run tests from Forked Repo
+
+on: 
+  pull_request_target:
+    types: [labeled]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.labels.*.name, 'Approved')
+    strategy:
+      matrix:
+        python-version: [ '3.10', '3.9', '3.8', '3.7', '3.6' ]
+    name: Python ${{ matrix.python-version }} sample
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: 'pipenv'
+      - run: pip install pipenv
+      - run: pipenv sync --dev
+      - run: pipenv run tests
+        env:
+          LOB_API_KEY: ${{ secrets.LOB_API_KEY }}


### PR DESCRIPTION
Because of security concerns with Github Secrets, we need to put in another GH action to be able to run tests (which make sure of the GH Secrets to hold the API keys). 