### PR TITLE
GC-1940/updates lob address

### DIFF
--- a/CODE_SNIPPETS.md
+++ b/CODE_SNIPPETS.md
@@ -1567,7 +1567,7 @@ with ApiClient(configuration) as api_client:
   api = UsVerificationsApi(api_client)
 
 verification_data_0 = MultipleComponents(
-  primary_line = "2261 Market Street,
+  primary_line = "2261 Market Street",
   city = "San Francisco",
   state = "CA",
   zip_code = "94114",

--- a/CODE_SNIPPETS.md
+++ b/CODE_SNIPPETS.md
@@ -55,11 +55,11 @@ address_editable = AddressEditable(
   company = "Lob",
   email = "harry@lob.com",
   phone = "5555555555",
-  address_line1 = "210 King St",
-  address_line2 = "# 6100",
+  address_line1 = "2261 Market Street",
+  address_line2 = "Ste 5668",
   address_city = "San Francisco",
   address_state = "CA",
-  address_zip = "94107",
+  address_zip = "94114",
   address_country = CountryExtended("US"),
 )
 
@@ -189,11 +189,11 @@ postcard_editable = PostcardEditable(
   back = "<html style='padding: 1in; font-size: 20;'>Back HTML for {{name}}</html>",
   to = AddressEditable(
     name = "Harry Zhang",
-    address_line1 = "210 King St",
-    address_line2 = "# 6100",
+    address_line1 = "2261 Market Street",
+    address_line2 = "Ste 5668",
     address_city = "San Francisco",
     address_state = "CA",
-    address_zip = "94107",
+    address_zip = "94114",
   ),
   merge_variables = MergeVariables(
     name = "Harry",
@@ -286,11 +286,11 @@ self_mailer_editable = SelfMailerEditable(
   outside = "<html style='padding: 1in; font-size: 20;'>Outside HTML for {{name}}</html>",
   to = AddressEditable(
     name = "Harry Zhang",
-    address_line1 = "210 King St",
-    address_line2 = "# 6100",
+    address_line1 = "2261 Market Street",
+    address_line2 = "Ste 5668",
     address_city = "San Francisco",
     address_state = "CA",
-    address_zip = "94107",
+    address_zip = "94114",
   ),
   merge_variables = MergeVariables(
     name = "Harry",
@@ -383,11 +383,11 @@ letter_editable = LetterEditable(
   color = True,
   to = AddressEditable(
     name = "Harry Zhang",
-    address_line1 = "210 King St",
-    address_line2 = "# 6100",
+    address_line1 = "2261 Market Street",
+    address_line2 = "Ste 5668",
     address_city = "San Francisco",
     address_state = "CA",
-    address_zip = "94107",
+    address_zip = "94114",
   ),
   merge_variables = MergeVariables(
     name = "Harry",
@@ -486,11 +486,11 @@ check_editable = CheckEditable(
   _from = "adr_210a8d4b0b76d77b",
   to = AddressDomestic(
     name = "Harry Zhang",
-    address_line1 = "210 King St",
-    address_line2 = "# 6100",
+    address_line1 = "2261 Market Street",
+    address_line2 = "Ste 5668",
     address_city = "San Francisco",
     address_state = "CA",
-    address_zip = "94107",
+    address_zip = "94114",
   ),
   merge_variables = MergeVariables(
     name = "Harry",
@@ -1552,10 +1552,10 @@ except ApiException as e:
 curl https://api.lob.com/v1/bulk/us_verifications \
   -u <YOUR LIVE API KEY>: \
   --header "Content-Type: application/x-www-form-urlencoded" \
-  --data-urlencode "addresses[0][primary_line]=210 King Street" \
+  --data-urlencode "addresses[0][primary_line]=2261 Market Street" \
   --data-urlencode "addresses[0][city]=San Francisco" \
   --data-urlencode "addresses[0][state]=CA" \
-  --data-urlencode "addresses[0][zip_code]=94017" \
+  --data-urlencode "addresses[0][zip_code]=94114" \
   --data-urlencode "addresses[1][primary_line]=185 BERRY ST STE 6600" \
   --data-urlencode "addresses[1][city]=SAN FRANCISCO" \
   --data-urlencode "addresses[1][state]=CA" \
@@ -1567,10 +1567,10 @@ with ApiClient(configuration) as api_client:
   api = UsVerificationsApi(api_client)
 
 verification_data_0 = MultipleComponents(
-  primary_line = "210 King Street",
+  primary_line = "2261 Market Street,
   city = "San Francisco",
   state = "CA",
-  zip_code = "94017",
+  zip_code = "94114",
 )
 
 verification_data_1 = MultipleComponents(
@@ -1598,20 +1598,20 @@ except ApiException as e:
 ```bash
 curl https://api.lob.com/v1/us_verifications \
   -u <YOUR_LIVE_API_KEY>: \
-  -d "primary_line=210 King Street" \
+  -d "primary_line=2261 Market Street" \
   -d "city=San Francisco" \
   -d "state=CA" \
-  -d "zip_code=94017" \
+  -d "zip_code=94114" \
 ```
 
 ```python
 with ApiClient(configuration) as api_client:
   api = UsVerificationsApi(api_client)
 verification_data_1 = UsVerificationsWritable(
-  primary_line = "210 King Street",
+  primary_line = "2261 Market Street",
   city = "San Francisco",
   state = "CA",
-  zip_code = "94017",
+  zip_code = "94114",
 )
 
 try:

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -50,11 +50,11 @@ lob.Address.create(
   company='Lob',
   email='harry@lob.com',
   phone='5555555555',
-  address_line1='210 King St',
-  address_line2='# 6100',
+  address_line1='2261 Market Street',
+  address_line2='Ste 5668',
   address_city='San Francisco',
   address_state='CA',
-  address_zip='94107',
+  address_zip='94114',
   address_country='US',
 )
 ```
@@ -68,11 +68,11 @@ address_editable = AddressEditable(
   company = "Lob",
   email = "harry@lob.com",
   phone = "5555555555",
-  address_line1 = "210 King St",
-  address_line2 = "# 6100",
+  address_line1 = "2261 Market Street",
+  address_line2 = "Ste 5668",
   address_city = "San Francisco",
   address_state = "CA",
-  address_zip = "94107",
+  address_zip = "94114",
   address_country = CountryExtended("US"),
 )
 

--- a/docs/UsVerificationsWritable.md
+++ b/docs/UsVerificationsWritable.md
@@ -4,7 +4,7 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**address** | **str** | The entire address in one string (e.g., \&quot;210 King Street 94107\&quot;). _Does not support a recipient and will error when other payload parameters are provided._  | [optional] 
+**address** | **str** | The entire address in one string (e.g., \&quot;2261 Market Street 94114\&quot;). _Does not support a recipient and will error when other payload parameters are provided._  | [optional] 
 **recipient** | [**Recipient**](Recipient.md) |  | [optional] 
 **primary_line** | [**PrimaryLineUs**](PrimaryLineUs.md) |  | [optional] 
 **secondary_line** | [**SecondaryLine**](SecondaryLine.md) |  | [optional] 

--- a/lob_python/model/us_verifications_writable.py
+++ b/lob_python/model/us_verifications_writable.py
@@ -167,7 +167,7 @@ class UsVerificationsWritable(ModelNormal):
                                 Animal class but this time we won't travel
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
-            address (str, type(None)): The entire address in one string (e.g., \"210 King Street 94107\"). _Does not support a recipient and will error when other payload parameters are provided._ . [optional] # noqa: E501
+            address (str, type(None)): The entire address in one string (e.g., \"2261 Market Street 94114\"). _Does not support a recipient and will error when other payload parameters are provided._ . [optional] # noqa: E501
             recipient (str, type(None)): [optional] # noqa: E501
             primary_line (str, type(None)): [optional] # noqa: E501
             secondary_line (str, type(None)): [optional] # noqa: E501
@@ -256,7 +256,7 @@ class UsVerificationsWritable(ModelNormal):
                                 Animal class but this time we won't travel
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
-            address (str, type(None)): The entire address in one string (e.g., \"210 King Street 94107\"). _Does not support a recipient and will error when other payload parameters are provided._ . [optional] # noqa: E501
+            address (str, type(None)): The entire address in one string (e.g., \"2261 Market Street 94114\"). _Does not support a recipient and will error when other payload parameters are provided._ . [optional] # noqa: E501
             recipient (str, type(None)): [optional] # noqa: E501
             primary_line (str, type(None)): [optional] # noqa: E501
             secondary_line (str, type(None)): [optional] # noqa: E501

--- a/test/Integration/test_us_autocompletions_api.py
+++ b/test/Integration/test_us_autocompletions_api.py
@@ -32,7 +32,7 @@ class TestUsAutocompletionsApi(unittest.TestCase):
         with lob_python.ApiClient(self.configuration) as self.api_client:
             self.api = UsAutocompletionsApi(self.api_client)  # noqa: E501
         self.valid_address = UsAutocompletionsWritable(
-            address_prefix = "210 KING",
+            address_prefix = "2261 MARKET",
             city = "SAN FRANCISCO",
         )
 
@@ -81,10 +81,10 @@ class TestUsAutocompletionsApi(unittest.TestCase):
         autocomplete  # noqa: E501
         """
         error_address = UsAutocompletionsWritable(
-            address_prefix = "210 KING",
+            address_prefix = "2261 MARKET",
             city = "SAN FRANCISCO",
             state = "CA",
-            zip_code = "94107",
+            zip_code = "94114",
             country = "GB"
         )
         with self.assertRaises(Exception) as context:

--- a/test/Integration/test_us_autocompletions_api.py
+++ b/test/Integration/test_us_autocompletions_api.py
@@ -32,7 +32,7 @@ class TestUsAutocompletionsApi(unittest.TestCase):
         with lob_python.ApiClient(self.configuration) as self.api_client:
             self.api = UsAutocompletionsApi(self.api_client)  # noqa: E501
         self.valid_address = UsAutocompletionsWritable(
-            address_prefix = "2261 MARKET",
+            address_prefix = "2261 MARKET ST",
             city = "SAN FRANCISCO",
         )
 
@@ -81,7 +81,7 @@ class TestUsAutocompletionsApi(unittest.TestCase):
         autocomplete  # noqa: E501
         """
         error_address = UsAutocompletionsWritable(
-            address_prefix = "2261 MARKET",
+            address_prefix = "2261 MARKET ST",
             city = "SAN FRANCISCO",
             state = "CA",
             zip_code = "94114",

--- a/test/assets/lobster-family.csv
+++ b/test/assets/lobster-family.csv
@@ -1,11 +1,11 @@
 recipient,primary line,city,state,zip_code
-Larry Lobster,210 King St,San Francisco,CA,94107
-Lloyd Lobster,210 King St,San Francisco,CA,94107
-Lisa Lobster,210 King St,San Francisco,CA,94107
-Linda Lobster,210 King St,San Francisco,CA,94107
-Leith Lobster,210 King St,San Francisco,CA,94107
+Larry Lobster,2261 Market Street,San Francisco,CA,94114
+Lloyd Lobster,2261 Market Street,San Francisco,CA,94114
+Lisa Lobster,2261 Market Street,San Francisco,CA,94114
+Linda Lobster,2261 Market Street,San Francisco,CA,94114
+Leith Lobster,2261 Market Street,San Francisco,CA,94114
 Lala Lobster,Not A Real Street,San Francisco,CA,94107
 Krusty Krab,212 King St,San Francisco,CA,94107
 Patrick Star,211 King St,San Francisco,CA,94107
 Christopher Crawdad,209 King St,San Francisco,CA,94107
-Lost Lobster,210 King St,,CA,
+Lost Lobster,2261 Market Street,,CA,

--- a/test/assets/lobster-family.csv
+++ b/test/assets/lobster-family.csv
@@ -1,11 +1,11 @@
 recipient,primary line,city,state,zip_code
-Larry Lobster,2261 Market Street,San Francisco,CA,94114
-Lloyd Lobster,2261 Market Street,San Francisco,CA,94114
-Lisa Lobster,2261 Market Street,San Francisco,CA,94114
-Linda Lobster,2261 Market Street,San Francisco,CA,94114
-Leith Lobster,2261 Market Street,San Francisco,CA,94114
+Larry Lobster,2261 Market St,San Francisco,CA,94114
+Lloyd Lobster,2261 Market St,San Francisco,CA,94114
+Lisa Lobster,2261 Market St,San Francisco,CA,94114
+Linda Lobster,2261 Market St,San Francisco,CA,94114
+Leith Lobster,2261 Market St,San Francisco,CA,94114
 Lala Lobster,Not A Real Street,San Francisco,CA,94107
 Krusty Krab,212 King St,San Francisco,CA,94107
 Patrick Star,211 King St,San Francisco,CA,94107
 Christopher Crawdad,209 King St,San Francisco,CA,94107
-Lost Lobster,2261 Market Street,,CA,
+Lost Lobster,2261 Market St,,CA,


### PR DESCRIPTION
[GC-1940](https://lobsters.atlassian.net/browse/GC-1940)

Updates Lob's address from "210 King Street, 94107" to "2261 Market Street STE 5668, 94114"

Tests fail for this PR. However, I checked and [they also fail on main](https://github.com/lob/lob-python/actions/runs/7542197758) and failed on [the previous PR](https://github.com/lob/lob-python/pull/205), so these failures are unrelated to this PR.

I created [GC-2168](https://lobsters.atlassian.net/browse/GC-2168) to fix these tests.

[GC-1940]: https://lobsters.atlassian.net/browse/GC-1940?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[GC-2168]: https://lobsters.atlassian.net/browse/GC-2168?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ