### PR TITLE
GC-2518/fixes letters tracking event validation

### DIFF
--- a/lob_python/model/letter.py
+++ b/lob_python/model/letter.py
@@ -97,12 +97,12 @@ class Letter(ModelNormal):
     }
 
     validations = {
-        ('file_template_id',): {
+        ('template_id',): {
             'regex': {
                 'pattern': r'^tmpl_[a-zA-Z0-9]+$',  # noqa: E501
             },
         },
-        ('file_template_version_id',): {
+        ('template_version_id',): {
             'regex': {
                 'pattern': r'^vrsn_[a-zA-Z0-9]+$',  # noqa: E501
             },

--- a/lob_python/model/letter.py
+++ b/lob_python/model/letter.py
@@ -96,11 +96,7 @@ class Letter(ModelNormal):
         },
     }
 
-    validations = {
-        ('tracking_events',): {
-            'max_items': 0,
-        },
-    }
+    validations = {}
 
     @cached_property
     def additional_properties_type():

--- a/lob_python/model/letter.py
+++ b/lob_python/model/letter.py
@@ -96,7 +96,18 @@ class Letter(ModelNormal):
         },
     }
 
-    validations = {}
+    validations = {
+        ('file_template_id',): {
+            'regex': {
+                'pattern': r'^tmpl_[a-zA-Z0-9]+$',  # noqa: E501
+            },
+        },
+        ('file_template_version_id',): {
+            'regex': {
+                'pattern': r'^vrsn_[a-zA-Z0-9]+$',  # noqa: E501
+            },
+        },
+    }
 
     @cached_property
     def additional_properties_type():

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@
 from setuptools import setup, find_packages  # noqa: H301
 
 NAME = "lob-python"
-VERSION = "5.1.2"
+VERSION = "5.1.3"
 # To install the library, run the following
 #
 # python setup.py install


### PR DESCRIPTION
Following [this slack thread](https://lob.slack.com/archives/C3DQ3K9U6/p1709851721432059), given we now allow tracking event for letters, we are removing the `max_items: 0` validation from `letters.tracking_events`

## Story

[GC-2518](https://lobsters.atlassian.net/browse/GC-2518)

Relates to https://github.com/lob/sdks_openapi_gen/pull/341

[GC-2518]: https://lobsters.atlassian.net/browse/GC-2518?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ