### PR TITLE
SYN-642: Clear high-severity Dependabot findings in pip deps

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.11"]
+        python-version: ["3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v4
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=78.1.1,<81"]
+build-backend = "setuptools.build_meta"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
-certifi==2022.12.7
+certifi==2026.7.22
 charset-normalizer==2.1.1
-idna==3.3
+idna==3.19
 lob==4.5.4
 python-dateutil==2.8.2
-requests==2.28.1
+requests==2.34.2
 six==1.16.0
-urllib3==1.26.12
+urllib3==2.7.0
 python-dotenv>=0.21.0

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@
 from setuptools import setup, find_packages  # noqa: H301
 
 NAME = "lob-python"
-VERSION = "5.2.0"
+VERSION = "5.2.1"
 # To install the library, run the following
 #
 # python setup.py install


### PR DESCRIPTION
# What problem are you trying to solve?

* 15 High Dependabot findings across urllib3, setuptools, and certifi ([SYN-642](https://lobsters.atlassian.net/browse/SYN-642)).

# How did you solve this problem?

* Bumped urllib3 1.26.12 to 2.7.0, certifi to 2026.7.22, requests to 2.34.2 (needed for urllib3 2.x compat), and idna to 3.19 in requirements.txt.
* Added pyproject.toml pinning setuptools>=78.1.1,<81 as a build dependency. It wasn't declared anywhere in the repo before.
* Bumped the CI matrix to Python 3.10/3.11/3.12 since the new dependency floors require it (3.8/3.9 are EOL).
* Dismissed 9 stale Dependabot alerts tied to Pipfile.lock, which was deleted from this repo in 2022 and no longer exists.

# Important notes

* 6 remaining High alerts against requirements.txt will auto-close once this merges and Dependabot rescans.
* I ran the full integration suite against old and new deps on the live API and got the same 11 errors and 2 failures either way. That's a pre-existing `return_envelope` model bug, unrelated to this change.

# Test plan

1. `pip-audit -r requirements.txt` -> 0 findings (was 23 across 4 packages)
2. `python -m unittest test/Unit/test_*.py` -> 247/247 pass
3. `python -m unittest discover test/Integration` (needs LOB_API_TEST_KEY) -> 135/148 pass, same as main
4. `python -m build --sdist` succeeds with the new pyproject.toml

[SYN-642]: https://lobsters.atlassian.net/browse/SYN-642?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ